### PR TITLE
Adding new .clang-format file for rocm2.5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,12 +23,14 @@ DisableFormat:   false
 Standard: Cpp11
 
 AccessModifierOffset: -4
-AlignAfterOpenBracket: true
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
-AlignEscapedNewlinesLeft: true
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
@@ -46,6 +48,7 @@ BinPackParameters: false
 BreakBeforeBraces: Custom
 # Control of individual brace wrapping cases
 BraceWrapping: {
+    AfterCaseLabel: 'true'
     AfterClass: 'true'
     AfterControlStatement: 'true'
     AfterEnum : 'true'
@@ -77,6 +80,7 @@ DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IndentCaseLabels: false
+IndentPPDirectives: None
 #FixNamespaceComments: true
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
@@ -116,5 +120,4 @@ SortIncludes: true
 ReflowComments: false
 
 #IncludeBlocks: Preserve
-#IndentPPDirectives: AfterHash
 ---


### PR DESCRIPTION
No files need to be changed. Just need to add some new settings to the clang-format file in order to keep up-to-date with hipSPARSE's and rocSPARSE's .clang-format files