### PR TITLE
Rocm2.6 CI upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 // This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
-@Library('rocJenkins@clang9') _
+@Library('rocJenkins') _
 
 // This is file for internal AMD use.
 // If you are interested in running your own Jenkins, please raise a github issue for assistance.


### PR DESCRIPTION
Just a one-line change in the Jenkinsfile. It won't affect the format check or any other stage of the pipeline, but it will enable rocm2.6 CI support for Ubuntu and CentOS