### PR TITLE
fixed email notification link for rocALUTIONCI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,7 +181,7 @@ rocALUTIONCImpi:
 rocALUTIONCI:
 {
 
-    def rocalution = new rocProject('rocalution')
+    def rocalution = new rocProject('rocALUTION')
     // customize for project
     rocalution.paths.build_command = './install.sh -c'
     rocalution.compiler.compiler_name = 'c++'


### PR DESCRIPTION
Fixes the link in email for build failure, but for rocALUTION, the link will only work for rocALUTIONCI, not the other two projects.