### PR TITLE
Rocm2.8 format check fix added

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -103,6 +103,7 @@ PointerAlignment: Left
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: Never
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false


### PR DESCRIPTION
This disables a new clang-format change in rocm2.8 that demands a space between empty brackets