### PR TITLE
rocALUTION changes to support multiple ROCM installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 # CMake modules
 list(APPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake
+     ${ROCM_PATH}/hip/cmake
      /opt/rocm/hip/cmake
 )
 

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -46,7 +46,7 @@ if(NOT TARGET rocalution)
   # This project may compile dependencies for clients
   project(rocalution-clients LANGUAGES CXX)
 
-  find_package(rocalution REQUIRED CONFIG PATHS /opt/rocm/rocalution)
+  find_package(rocalution REQUIRED CONFIG PATHS ${ROCM_PATH}/rocalution /opt/rocm/rocalution)
 
   option(BUILD_CLIENTS_SAMPLES "Build examples." ON)
   option(SUPPORT_MPI "Build MPI examples." OFF)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -28,7 +28,7 @@ find_package(Git REQUIRED)
 
 # Workaround until hcc & hip cmake modules fixes symlink logic in their config files.
 # (Thanks to rocBLAS devs for finding workaround for this problem!)
-list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip /opt/rocm)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hcc /opt/rocm/hcc ${ROCM_PATH}/hip /opt/rocm/hip ${ROCM_PATH} /opt/rocm)
 
 # Find OpenMP package
 find_package(OpenMP)

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -44,11 +44,11 @@ function(rocm_create_package_clients)
     if(EXISTS "${PROJECT_BINARY_DIR}/package")
         file(REMOVE_RECURSE "${PROJECT_BINARY_DIR}/package")
     endif()
-    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/opt/rocm/${PARSE_LIB_NAME}/bin")
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/bin")
     file(WRITE "${PROJECT_BINARY_DIR}/package/DEBIAN/control" ${DEB_CONTROL_FILE_CONTENT})
 
     add_custom_target(package_clients
-        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/opt/rocm/${PARSE_LIB_NAME}/bin/*"
-        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/opt/rocm/${PARSE_LIB_NAME}/bin"
+        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/bin/*"
+        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/bin"
         COMMAND dpkg -b "${PROJECT_BINARY_DIR}/package/"  ${PACKAGE_NAME})
 endfunction(rocm_create_package_clients)

--- a/install.sh
+++ b/install.sh
@@ -241,13 +241,18 @@ supported_distro
 # #################################################
 install_package=false
 install_dependencies=false
-install_prefix=rocalution-install
 build_clients=false
 build_host=false
 build_mpi=false
 build_omp=true
 build_release=true
 build_dir=./build
+install_prefix=rocalution-install
+
+rocm_path=/opt/rocm
+if ! [ -z ${ROCM_PATH+x} ]; then
+  rocm_path=${ROCM_PATH}
+fi
 
 # #################################################
 # Parameter parsing
@@ -349,7 +354,7 @@ fi
 
 # We append customary rocm path; if user provides custom rocm path in ${path}, our
 # hard-coded path has lesser priority
-export PATH=${PATH}:/opt/rocm/bin
+export PATH=${PATH}:${rocm_path}/bin:/opt/rocm/bin
 
 pushd .
   # #################################################
@@ -390,10 +395,10 @@ pushd .
   fi
 
   # cpack
-  cmake_common_options="${cmake_common_options} -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm"
+  cmake_common_options="${cmake_common_options} -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=${rocm_path}"
 
   # Build library with AMD toolchain because of existense of device kernels
-  ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCMAKE_INSTALL_PREFIX=rocalution-install ../..
+  ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCMAKE_INSTALL_PREFIX=${install_prefix} -DROCM_PATH=${rocm_path} ../..
   check_exit_code
 
   make -j$(nproc) install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,11 @@ endif()
 add_library(rocalution ${SOURCE} ${PUBLIC_HEADERS})
 add_library(roc::rocalution ALIAS rocalution)
 
+# RUNPATH is set only when ROCM_RPATH is defined in the ENV
+if( DEFINED ENV{ROCM_RPATH} )
+  set ( CMAKE_SHARED_LINKER_FLAGS " -Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}" )
+endif( )
+
 # Target link libraries
 if(SUPPORT_OMP)
 target_link_libraries(rocalution PRIVATE ${OpenMP_CXX_FLAGS})


### PR DESCRIPTION
- ROCm stack install path needs to be provided using the
  variable ROCM_PATH as a cmake parameter. If it is not
  provided, ROCm stack components are searched in /opt/rocm
- Package is generated to install into ROCM_PATH by setting
  it to CPACK_PACKAGING_INSTALL_PREFIX, if defined in the env
  otherwise default into /opt/rocm
- RUNPATH is set in the lib only if ROCM_RPATH env is defined
  with the rpath

Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>