### PR TITLE
rocALUTION Separate build flag to support multiple ROCM installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ endif()
 # CMake modules
 list(APPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake
-     ${ROCM_PATH}/hip/cmake
      /opt/rocm/hip/cmake
 )
 

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -46,7 +46,7 @@ if(NOT TARGET rocalution)
   # This project may compile dependencies for clients
   project(rocalution-clients LANGUAGES CXX)
 
-  find_package(rocalution REQUIRED CONFIG PATHS ${ROCM_PATH}/rocalution /opt/rocm/rocalution)
+  find_package(rocalution REQUIRED CONFIG PATHS /opt/rocm/rocalution)
 
   option(BUILD_CLIENTS_SAMPLES "Build examples." ON)
   option(SUPPORT_MPI "Build MPI examples." OFF)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -28,7 +28,7 @@ find_package(Git REQUIRED)
 
 # Workaround until hcc & hip cmake modules fixes symlink logic in their config files.
 # (Thanks to rocBLAS devs for finding workaround for this problem!)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hcc /opt/rocm/hcc ${ROCM_PATH}/hip /opt/rocm/hip ${ROCM_PATH} /opt/rocm)
+list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip /opt/rocm)
 
 # Find OpenMP package
 find_package(OpenMP)

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -44,11 +44,11 @@ function(rocm_create_package_clients)
     if(EXISTS "${PROJECT_BINARY_DIR}/package")
         file(REMOVE_RECURSE "${PROJECT_BINARY_DIR}/package")
     endif()
-    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/bin")
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/${ROCM_PATH}/${PARSE_LIB_NAME}/bin")
     file(WRITE "${PROJECT_BINARY_DIR}/package/DEBIAN/control" ${DEB_CONTROL_FILE_CONTENT})
 
     add_custom_target(package_clients
-        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/bin/*"
-        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/bin"
+        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/${ROCM_PATH}/${PARSE_LIB_NAME}/bin/*"
+        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/${ROCM_PATH}/${PARSE_LIB_NAME}/bin"
         COMMAND dpkg -b "${PROJECT_BINARY_DIR}/package/"  ${PACKAGE_NAME})
 endfunction(rocm_create_package_clients)

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,7 @@ function display_help()
 #  echo "    [--prefix] Specify an alternate CMAKE_INSTALL_PREFIX for cmake"
   echo "    [-i|--install] install after build"
   echo "    [-d|--dependencies] install build dependencies"
+  echo "    [-r]--relocatable] create a package to support relocatable ROCm"
   echo "    [-c|--clients] build library clients too (combines with -i & -d)"
   echo "    [-g|--debug] -DCMAKE_BUILD_TYPE=Debug (default is =Release)"
   echo "    [--build-dir] build directory (default is ./build)"
@@ -248,11 +249,8 @@ build_omp=true
 build_release=true
 build_dir=./build
 install_prefix=rocalution-install
-
 rocm_path=/opt/rocm
-if ! [ -z ${ROCM_PATH+x} ]; then
-  rocm_path=${ROCM_PATH}
-fi
+build_relocatable=false
 
 # #################################################
 # Parameter parsing
@@ -261,7 +259,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,build-dir:,host,no-openmp,mpi --options hicgd -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,build-dir:,host,no-openmp,mpi,relocatable --options hicgdr -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -288,6 +286,9 @@ while true; do
         shift ;;
     -c|--clients)
         build_clients=true
+        shift ;;
+    -r|--relocatable)
+        build_relocatable=true
         shift ;;
     -g|--debug)
         build_release=false
@@ -326,6 +327,17 @@ else
   rm -rf ${build_dir}/debug
 fi
 
+if [[ "${build_relocatable}" == true ]]; then
+    if ! [ -z ${ROCM_PATH+x} ]; then
+        rocm_path=${ROCM_PATH}
+    fi
+
+    rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
+    if ! [ -z ${ROCM_RPATH+x} ]; then
+        rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"
+    fi
+fi
+
 # Default cmake executable is called cmake
 cmake_executable=cmake
 
@@ -354,7 +366,11 @@ fi
 
 # We append customary rocm path; if user provides custom rocm path in ${path}, our
 # hard-coded path has lesser priority
-export PATH=${PATH}:${rocm_path}/bin:/opt/rocm/bin
+if [[ "${build_relocatable}" == true ]]; then
+    export PATH=${rocm_path}/bin:${PATH}
+else
+    export PATH=${PATH}:/opt/rocm/bin
+fi
 
 pushd .
   # #################################################
@@ -395,10 +411,25 @@ pushd .
   fi
 
   # cpack
-  cmake_common_options="${cmake_common_options} -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=${rocm_path}"
+  if [[ "${build_relocatable}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=${rocm_path}"
+  else
+    cmake_common_options="${cmake_common_options} -DCPACK_SET_DESTDIR=OFF -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm"
+  fi
 
   # Build library with AMD toolchain because of existense of device kernels
-  ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCMAKE_INSTALL_PREFIX=${install_prefix} -DROCM_PATH=${rocm_path} ../..
+  if [[ "${build_relocatable}" == true ]]; then
+    ${cmake_executable} ${cmake_common_options} ${cmake_client_options} \
+      -DCMAKE_INSTALL_PREFIX=${rocm_path} \
+      -DCMAKE_SHARED_LINKER_FLAGS=${rocm_rpath} \
+      -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
+      -DCMAKE_MODULE_PATH="${rocm_path}/hip/cmake" \
+      -DROCM_DISABLE_LDCONFIG=ON \
+      -DROCM_PATH=${rocm_path} ../..
+  else
+    ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCMAKE_INSTALL_PREFIX=${install_prefix} -DROCM_PATH=${rocm_path} ../..
+  fi
+
   check_exit_code
 
   make -j$(nproc) install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,11 +84,6 @@ endif()
 add_library(rocalution ${SOURCE} ${PUBLIC_HEADERS})
 add_library(roc::rocalution ALIAS rocalution)
 
-# RUNPATH is set only when ROCM_RPATH is defined in the ENV
-if( DEFINED ENV{ROCM_RPATH} )
-  set ( CMAKE_SHARED_LINKER_FLAGS " -Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}" )
-endif( )
-
 # Target link libraries
 if(SUPPORT_OMP)
 target_link_libraries(rocalution PRIVATE ${OpenMP_CXX_FLAGS})


### PR DESCRIPTION
- New mode of building is added "-r,--relocatable" which is used
  for ROCm stack installed in /opt/rocm-ver.
- Below CMAKE parameters are set/overwritten in above mode
    CMAKE_INSTALL_PREFIX
    CPACK_PACKAGING_INSTALL_PREFIX
    CMAKE_PREFIX_PATH
    CMAKE_SHARED_LINKER_FLAGS
    ROCM_DISABLE_LDCONFIG
    ROCM_PATH

Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>