### PR TITLE
rocALUTION Separate build flag to support multiple ROCM installation

### DIFF
--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -44,11 +44,11 @@ function(rocm_create_package_clients)
     if(EXISTS "${PROJECT_BINARY_DIR}/package")
         file(REMOVE_RECURSE "${PROJECT_BINARY_DIR}/package")
     endif()
-    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/opt/rocm/${PARSE_LIB_NAME}/bin")
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/${ROCM_PATH}/${PARSE_LIB_NAME}/bin")
     file(WRITE "${PROJECT_BINARY_DIR}/package/DEBIAN/control" ${DEB_CONTROL_FILE_CONTENT})
 
     add_custom_target(package_clients
-        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/opt/rocm/${PARSE_LIB_NAME}/bin/*"
-        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/opt/rocm/${PARSE_LIB_NAME}/bin"
+        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/${ROCM_PATH}/${PARSE_LIB_NAME}/bin/*"
+        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/${ROCM_PATH}/${PARSE_LIB_NAME}/bin"
         COMMAND dpkg -b "${PROJECT_BINARY_DIR}/package/"  ${PACKAGE_NAME})
 endfunction(rocm_create_package_clients)


### PR DESCRIPTION
- New mode of building is added "-r,--relocatable" which is used
  for ROCm stack installed in /opt/rocm-ver.
- Below CMAKE parameters are set/overwritten in above mode
    CMAKE_INSTALL_PREFIX
    CPACK_PACKAGING_INSTALL_PREFIX
    CMAKE_PREFIX_PATH
    CMAKE_SHARED_LINKER_FLAGS
    ROCM_DISABLE_LDCONFIG
    ROCM_PATH

Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>