### PR TITLE
Updated HIP Bin prefix Path to rocm_path

### DIFF
--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -1,8 +1,8 @@
 
 if (DEFINED ENV{ROCM_PATH})
-  set(rocm_bin "$ENV{ROCM_PATH}/hip/bin")
+  set(rocm_bin "$ENV{ROCM_PATH}/bin")
 else()
-  set(rocm_bin "/opt/rocm/hip/bin")
+  set(rocm_bin "/opt/rocm/bin")
 endif()
 
 set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc")


### PR DESCRIPTION
Proposed Changes:

- Update HIP bin prefix path to rocm_path (rocm_path/bin will be used for hipcc as per the reorg structure)