### PR TITLE
Fix for old version rocm folder not removed on upgrade of meta packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,8 +157,6 @@ else()
   endif()
 endif()
 
-set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
-
 # Package name
 set(package_name rocalution)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,8 @@ else()
   endif()
 endif()
 
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" )
+
 # Package name
 set(package_name rocalution)
 


### PR DESCRIPTION
Proposed Changes:
- Fix for SWDEV-344187
- Removed CPACK_PACKAGING_INSTALL_PREFIX}/CMAKE_INSTALL_INCLUDEDIR 
from CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION list of exclude path