### PR TITLE
Remove RPATH/RUNPATH from ROCm libraries and binaries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -519,10 +519,10 @@ pushd .
   if [[ "${build_relocatable}" == true ]]; then
     CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} \
       -DCMAKE_INSTALL_PREFIX="${install_prefix}" \
-      -DCMAKE_SHARED_LINKER_FLAGS=" " \
+      -DCMAKE_SHARED_LINKER_FLAGS="" \
       -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
       -DCMAKE_MODULE_PATH="${rocm_path}/lib/cmake/hip ${rocm_path}/hip/cmake" \
-      -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--enable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \
+      -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--disable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \
       -DROCM_DISABLE_LDCONFIG=ON \
       -DROCM_PATH="${rocm_path}" ../..
   else

--- a/install.sh
+++ b/install.sh
@@ -383,11 +383,6 @@ if [[ "${build_relocatable}" == true ]]; then
     if ! [ -z ${ROCM_PATH+x} ]; then
         rocm_path=${ROCM_PATH}
     fi
-
-    rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
-    if ! [ -z ${ROCM_RPATH+x} ]; then
-        rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"
-    fi
 fi
 
 # Default cmake executable is called cmake
@@ -524,7 +519,7 @@ pushd .
   if [[ "${build_relocatable}" == true ]]; then
     CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} \
       -DCMAKE_INSTALL_PREFIX="${install_prefix}" \
-      -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" \
+      -DCMAKE_SHARED_LINKER_FLAGS=" " \
       -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
       -DCMAKE_MODULE_PATH="${rocm_path}/lib/cmake/hip ${rocm_path}/hip/cmake" \
       -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--enable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \

--- a/install.sh
+++ b/install.sh
@@ -519,10 +519,9 @@ pushd .
   if [[ "${build_relocatable}" == true ]]; then
     CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} \
       -DCMAKE_INSTALL_PREFIX="${install_prefix}" \
-      -DCMAKE_SHARED_LINKER_FLAGS="" \
       -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
       -DCMAKE_MODULE_PATH="${rocm_path}/lib/cmake/hip ${rocm_path}/hip/cmake" \
-      -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--disable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \
+      -DCMAKE_SKIP_INSTALL_RPATH=TRUE \
       -DROCM_DISABLE_LDCONFIG=ON \
       -DROCM_PATH="${rocm_path}" ../..
   else


### PR DESCRIPTION
SWDEV-310152:
- Single version package: add ldconfig, no RPATH/RUNPATH in either binaries or libraries
- Multi version package: use RPATH for binaries, no RPATH/RUNPATH for libraries
- amdclang/clang/hipcc compilers shall not add RPATH/RUNPATH to produced binaries or libraries unless explicitly requested by an option
- Versioning scripts will take care of adding rpath to binaries for multi version package