### PR TITLE
SWDEV-438085 - Use the compile option -DNDEBUG while building rocalution_hip library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,6 +166,10 @@ if(SUPPORT_HIP)
     endif()
 
     list(APPEND HIP_HIPCC_FLAGS "-O3 -fPIC -std=c++14")
+    # Use -DNDEBUG compile option for Release and RelWithDebInfo build
+    if((${CMAKE_BUILD_TYPE} MATCHES "Release") OR (${CMAKE_BUILD_TYPE} MATCHES "RelWithDebInfo"))
+      list(APPEND HIP_HIPCC_FLAGS "-DNDEBUG")
+    endif()
     foreach(target ${AMDGPU_TARGETS})
       list(APPEND HIP_HIPCC_FLAGS "--offload-arch=${target}")
     endforeach()


### PR DESCRIPTION
Since hip_add_library is used for creating the library, the option need to be passed explicitly for cmake build type Release and RelWithDebInfo