### PR TITLE
Include `<cstdint>` in headers that use fixed width integer types.

### DIFF
--- a/src/base/backend_manager.hpp
+++ b/src/base/backend_manager.hpp
@@ -26,6 +26,7 @@
 
 #include "rocalution/export.hpp"
 
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <map>

--- a/src/base/host/host_io.hpp
+++ b/src/base/host/host_io.hpp
@@ -24,6 +24,7 @@
 #ifndef ROCALUTION_HOST_IO_HPP_
 #define ROCALUTION_HOST_IO_HPP_
 
+#include <cstdint>
 #include <string>
 
 namespace rocalution

--- a/src/base/matrix_formats.hpp
+++ b/src/base/matrix_formats.hpp
@@ -24,6 +24,7 @@
 #ifndef ROCALUTION_MATRIX_FORMATS_HPP_
 #define ROCALUTION_MATRIX_FORMATS_HPP_
 
+#include <cstdint>
 #include <string>
 
 namespace rocalution

--- a/src/solvers/iter_ctrl.hpp
+++ b/src/solvers/iter_ctrl.hpp
@@ -24,6 +24,7 @@
 #ifndef ROCALUTION_ITER_CTRL_HPP_
 #define ROCALUTION_ITER_CTRL_HPP_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/utils/math_functions.hpp
+++ b/src/utils/math_functions.hpp
@@ -24,6 +24,7 @@
 #ifndef ROCALUTION_UTILS_MATH_FUNCTIONS_HPP_
 #define ROCALUTION_UTILS_MATH_FUNCTIONS_HPP_
 
+#include <cstdint>
 #include <complex>
 
 namespace rocalution


### PR DESCRIPTION
The STL implementation from newer versions of GCC implicitly include `<cstdint>` in less headers.
Include that header explicitly in files that use fixed width integer types (like `int64_t`) to fix a compilation error with these versions of GCC.