### PR TITLE
Do not export functions that are defined inline in headers.

### DIFF
--- a/src/base/parallel_manager.hpp
+++ b/src/base/parallel_manager.hpp
@@ -63,14 +63,12 @@ namespace rocalution
         void Clear(void);
 
         /** \brief Return communicator */
-        ROCALUTION_EXPORT
         const void* GetComm(void) const
         {
             return this->comm_;
         }
 
         /** \brief Return rank */
-        ROCALUTION_EXPORT
         int GetRank(void) const
         {
             return this->rank_;

--- a/src/solvers/preconditioners/preconditioner_multielimination.hpp
+++ b/src/solvers/preconditioners/preconditioner_multielimination.hpp
@@ -68,14 +68,12 @@ namespace rocalution
         virtual ~MultiElimination();
 
         /** \brief Returns the size of the first (diagonal) block of the preconditioner */
-        ROCALUTION_EXPORT
         inline int GetSizeDiagBlock(void) const
         {
             return this->size_;
         }
 
         /** \brief Return the depth of the current level */
-        ROCALUTION_EXPORT
         inline int GetLevel(void) const
         {
             return this->level_;

--- a/src/solvers/solver.hpp
+++ b/src/solvers/solver.hpp
@@ -246,14 +246,12 @@ namespace rocalution
         virtual void SetSolverDescriptor(const SolverDescr& descr);
 
         /** \brief Mark this solver as being a preconditioner */
-        ROCALUTION_EXPORT
         inline void FlagPrecond(void)
         {
             this->is_precond_ = true;
         }
 
         /** \brief Mark this solver as being a smoother */
-        ROCALUTION_EXPORT
         inline void FlagSmoother(void)
         {
             this->is_smoother_ = true;


### PR DESCRIPTION
Functions that are defined (inline) in headers are available to the including compilation unit. They do not need to be exported from a shared library for any platform.
Adding a `dllimport` attribute to function definitions is an error on Windows (at least for MinGW with GCC).

Remove the export (and more importantly the `dllimport`) attributes for functions that are defined inline in headers to avoid that error.