### PR TITLE
host_vector.cpp: Define `_USE_MATH_DEFINES` if `_WIN32` is defined.

### DIFF
--- a/src/base/host/host_vector.cpp
+++ b/src/base/host/host_vector.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  *
  * ************************************************************************ */
-#if defined(WIN32)
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
 #define _USE_MATH_DEFINES
 #endif
 


### PR DESCRIPTION
This fixes a build issue with MSVC 2022 v17.11:
```
.../rocALUTION/src/base/host/host_vector.cpp:400:62: error: no member named 'M_PI' in 'rocalution::HostVector<float>'
  400 |                             * cos(static_cast<ValueType>(2 * M_PI) * u2);
      |                                                              ^
```

The preprocessor condition for whether to define `_USE_MATH_DEFINES` currently checks whether `WIN32` is defined. But it is not for that compiler.
It should be enough to check whether `_WIN32` (note the leading underscore) is defined:
http://msdn.microsoft.com/en-us/library/ff540443.aspx

But in other places in the code base more alternative spellings are checked. So, use the same condition here, too.