### PR TITLE
Deprecate AMDGPU_TARGETS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ else()
   )
 endif()
 set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+# Don't force, as users should be able to override GPU_TARGETS at the command line if desired
+set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for")
 
 include(CheckLanguage)
 include(CMakeDependentOption)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,11 @@ else()
     gfx1201
   )
 endif()
-set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
-# Don't force, as users should be able to override GPU_TARGETS at the command line if desired
+if(AMDGPU_TARGETS AND NOT GPU_TARGETS)
+  message( DEPRECATION "AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS." )
+endif()
+set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "Target default GPUs if AMDGPU_TARGETS is not defined. (Deprecated, prefer GPU_TARGETS)")
+# Don't force, users should be able to override GPU_TARGETS at the command line if desired
 set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for")
 
 include(CheckLanguage)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,7 +183,7 @@ if(SUPPORT_HIP)
     if((${CMAKE_BUILD_TYPE} MATCHES "Release") OR (${CMAKE_BUILD_TYPE} MATCHES "RelWithDebInfo"))
       list(APPEND HIP_HIPCC_FLAGS "-DNDEBUG")
     endif()
-    foreach(target ${AMDGPU_TARGETS})
+    foreach(target ${GPU_TARGETS})
       list(APPEND HIP_HIPCC_FLAGS "--offload-arch=${target}")
     endforeach()
 


### PR DESCRIPTION
Summary of proposed changes:

- Change the CMake to set the GPU_TARGETS variable from AMDGPU_TARGETS if not set by the user
- Change usages of AMDGPU_TARGETS to GPU_TARGETS