### PR TITLE
Updated toolchain-windows.cmake file for HIP_PATH env variable

### DIFF
--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -1,5 +1,8 @@
 
-if (DEFINED ENV{HIP_DIR})
+if (DEFINED ENV{HIP_PATH})
+  file(TO_CMAKE_PATH "$ENV{HIP_PATH}" HIP_DIR)
+  set(rocm_bin "${HIP_DIR}/bin")
+elseif (DEFINED ENV{HIP_DIR})
   file(TO_CMAKE_PATH "$ENV{HIP_DIR}" HIP_DIR)
   set(rocm_bin "${HIP_DIR}/bin")
 else()


### PR DESCRIPTION
resolves HIP_SDK manual building failure in Windows

Summary of proposed changes:
This change needed as the manual build in windows machine failed as HIP_SDK creates environment variable 'HIP_PATH', but rocALUTION library 'toolchain-windows.cmake' file referring only to HIP_DIR environment variable