### PR TITLE
Build chain updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation forrocALUTION is available at [https://rocm.docs.amd.com/projects/rocALUTION/en/latest/](https://rocm.docs.amd.com/projects/rocALUTION/en/latest/).
 
-## (Unreleased) rocALUTION 3.2.4
+## (Unreleased) rocALUTION 4.0.0
 
 ## rocALUTION 3.2.3 for ROCm 6.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ Full documentation forrocALUTION is available at [https://rocm.docs.amd.com/proj
 
 ## (Unreleased) rocALUTION 4.0.0
 
-## rocALUTION 3.2.4 for ROCm 6.5.0
-
 ### Added
 * Added support for gfx950.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ endif()
 
 
 # Setup version
-rocm_setup_version(VERSION "3.2.3")
+rocm_setup_version(VERSION "4.0.0")
 
 if(BUILD_CLIENTS_SAMPLES OR BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   set( BUILD_CLIENTS ON )

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2018-2021 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -65,33 +65,36 @@ else()
 endif()
 
 # ROCm cmake package
-set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
-find_package(ROCM 0.7.3 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH})
-if(NOT ROCM_FOUND)
-  set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
-  file(DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
-       ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
+find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET PATHS ${CMAKE_PREFIX_PATH})
+if(NOT ROCmCMakeBuildTools_FOUND)
+  find_package(ROCM 0.11.0 CONFIG QUIET PATHS ${CMAKE_PREFIX_PATH}) # deprecated fallback
+  if(NOT ROCM_FOUND)
+    set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
+    set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
+    file(DOWNLOAD https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip
+         ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
 
-  list(GET status 0 status_code)
-  list(GET status 1 status_string)
+    list(GET status 0 status_code)
+    list(GET status 1 status_string)
 
-  if(NOT status_code EQUAL 0)
-    message(FATAL_ERROR "error: downloading
-    'https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
-    status_code: ${status_code}
-    status_string: ${status_string}
-    log: ${log}
-    ")
+    if(NOT status_code EQUAL 0)
+      message(FATAL_ERROR "error: downloading
+      'https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
+      status_code: ${status_code}
+      status_string: ${status_string}
+      log: ${log}
+      ")
+    endif()
   endif()
 
   execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
                   WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
-  execute_process( COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag} )
-  execute_process( COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
+  execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
+                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag})
+  execute_process(COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
                   WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
 
-  find_package(ROCM 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake)
+  find_package(ROCmCMakeBuildTools 0.11.0 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake)
 endif()
 
 include(ROCMSetupVersion)
@@ -99,5 +102,6 @@ include(ROCMCreatePackage)
 include(ROCMInstallTargets)
 include(ROCMPackageConfigHelpers)
 include(ROCMInstallSymlinks)
-include(ROCMHeaderWrapper)
+include(ROCMCheckTargetIds)
 include(ROCMClients)
+include(ROCMHeaderWrapper)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -23,6 +23,8 @@
 
 # Dependencies
 
+include(FetchContent)
+
 # Find OpenMP package
 find_package(OpenMP)
 if (NOT OPENMP_FOUND)
@@ -67,34 +69,20 @@ endif()
 # ROCm cmake package
 find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET PATHS ${CMAKE_PREFIX_PATH})
 if(NOT ROCmCMakeBuildTools_FOUND)
-  find_package(ROCM 0.11.0 CONFIG QUIET PATHS ${CMAKE_PREFIX_PATH}) # deprecated fallback
+  find_package(ROCM 0.7.3 CONFIG QUIET PATHS ${CMAKE_PREFIX_PATH}) # deprecated fallback
   if(NOT ROCM_FOUND)
+    message(STATUS "ROCmCMakeBuildTools not found. Fetching...")
     set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
-    set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
-    file(DOWNLOAD https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip
-         ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
-
-    list(GET status 0 status_code)
-    list(GET status 1 status_string)
-
-    if(NOT status_code EQUAL 0)
-      message(FATAL_ERROR "error: downloading
-      'https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
-      status_code: ${status_code}
-      status_string: ${status_string}
-      log: ${log}
-      ")
-    endif()
+    set(rocm_cmake_tag "rocm-6.4.0" CACHE STRING "rocm-cmake tag to download")
+    FetchContent_Declare(
+      rocm-cmake
+      GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git
+      GIT_TAG ${rocm_cmake_tag}
+      SOURCE_SUBDIR "DISABLE ADDING TO BUILD"
+    )
+    FetchContent_MakeAvailable(rocm-cmake)
+    find_package(ROCmCMakeBuildTools CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
   endif()
-
-  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
-  execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag})
-  execute_process(COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
-
-  find_package(ROCmCMakeBuildTools 0.11.0 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake)
 endif()
 
 include(ROCMSetupVersion)


### PR DESCRIPTION
- Update to build chain (ROCM package is deprecated and replaced by ROCmCMakeBuildTools)
- Major version bump