### PR TITLE
Fix rocalution documentation for references to LocalVector::operator[] and RugeStueben::SetStrengthThreshold

### DIFF
--- a/docs/reference/rocALUTION-single-node-comp.rst
+++ b/docs/reference/rocALUTION-single-node-comp.rst
@@ -362,9 +362,9 @@ File I/O
 Access
 ======
 
-.. doxygenfunction:: rocalution::LocalVector::&operator[](int)
+.. doxygenfunction:: rocalution::LocalVector::operator[](int64_t)
   :outline:
-.. doxygenfunction:: rocalution::LocalVector::&operator[](int) const
+.. doxygenfunction:: rocalution::LocalVector::operator[](int64_t) const
 
 .. note:: 
 

--- a/docs/reference/rocALUTION-solvers.rst
+++ b/docs/reference/rocALUTION-solvers.rst
@@ -226,7 +226,7 @@ Ruge-stueben AMG
 ================
 
 .. doxygenclass:: rocalution::RugeStuebenAMG
-.. doxygenfunction:: rocalution::RugeStuebenAMG::SetCouplingStrength
+.. doxygenfunction:: rocalution::RugeStuebenAMG::SetStrengthThreshold
 
 Pairwise AMG
 ============


### PR DESCRIPTION
Summary of proposed changes:
- Fix rocalution documentation for references to LocalVector::operator[] and RugeStueben::SetStrengthThreshold
- Fixes https://github.com/ROCm/rocALUTION/issues/263