### PR TITLE
exclude parts of the code for the code coverage using LCOV_EXCL

### DIFF
--- a/src/base/backend_manager.cpp
+++ b/src/base/backend_manager.cpp
@@ -198,9 +198,11 @@ namespace rocalution
 
         if(_rocalution_check_if_any_obj() == false)
         {
+            // LCOV_EXCL_START
             LOG_INFO("Error: rocALUTION objects have been created before calling the "
                      "init_rocalution()!");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         _get_backend_descriptor()->init = true;

--- a/src/base/base_rocalution.cpp
+++ b/src/base/base_rocalution.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -73,6 +73,7 @@ namespace rocalution
         assert(_get_backend_descriptor()->init == true);
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     BaseRocalution<ValueType>::BaseRocalution(const BaseRocalution<ValueType>& src)
     {
@@ -81,6 +82,7 @@ namespace rocalution
         LOG_INFO("no copy constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     BaseRocalution<ValueType>::~BaseRocalution()
@@ -88,6 +90,7 @@ namespace rocalution
         log_debug(this, "BaseRocalution::~BaseRocalution()");
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     BaseRocalution<ValueType>&
         BaseRocalution<ValueType>::operator=(const BaseRocalution<ValueType>& src)
@@ -97,6 +100,7 @@ namespace rocalution
         LOG_INFO("no overloaded operator=()");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     void BaseRocalution<ValueType>::CloneBackend(const BaseRocalution<ValueType>& src)

--- a/src/base/base_vector.cpp
+++ b/src/base/base_vector.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -59,6 +59,7 @@ namespace rocalution
         this->local_backend_ = local_backend;
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     bool BaseVector<ValueType>::Check(void) const
     {
@@ -68,7 +69,6 @@ namespace rocalution
         FATAL_ERROR(__FILE__, __LINE__);
     }
 
-    // LCOV_EXCL_START
     template <typename ValueType>
     void BaseVector<ValueType>::CopyFromData(const ValueType* data)
     {
@@ -104,7 +104,6 @@ namespace rocalution
         LOG_INFO("This function is not available for this backend");
         FATAL_ERROR(__FILE__, __LINE__);
     }
-    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     void BaseVector<ValueType>::CopyFromFloat(const BaseVector<float>& vec)
@@ -157,6 +156,7 @@ namespace rocalution
 
         this->CopyTo(vec);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     AcceleratorVector<ValueType>::AcceleratorVector()
@@ -168,6 +168,7 @@ namespace rocalution
     {
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void AcceleratorVector<ValueType>::CopyFromHostAsync(const HostVector<ValueType>& src)
     {
@@ -181,6 +182,7 @@ namespace rocalution
         // default is no async
         this->CopyToHost(dst);
     }
+    // LCOV_EXCL_STOP
 
     template class BaseVector<double>;
     template class BaseVector<float>;

--- a/src/base/host/host_affinity.cpp
+++ b/src/base/host/host_affinity.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2020 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -78,8 +78,10 @@ namespace rocalution
 
             if(numCPU == 0)
             {
+                // LCOV_EXCL_START
                 LOG_VERBOSE_INFO(2, "Unsuporrted OS, no core information is available");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
             else
             {

--- a/src/base/host/host_matrix_bcsr.cpp
+++ b/src/base/host/host_matrix_bcsr.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,6 +43,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostMatrixBCSR<ValueType>::HostMatrixBCSR()
     {
@@ -50,6 +51,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     HostMatrixBCSR<ValueType>::HostMatrixBCSR(const Rocalution_Backend_Descriptor& local_backend,

--- a/src/base/host/host_matrix_coo.cpp
+++ b/src/base/host/host_matrix_coo.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostMatrixCOO<ValueType>::HostMatrixCOO()
     {
@@ -57,6 +58,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     HostMatrixCOO<ValueType>::HostMatrixCOO(const Rocalution_Backend_Descriptor& local_backend)

--- a/src/base/host/host_matrix_csr.cpp
+++ b/src/base/host/host_matrix_csr.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,6 +66,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostMatrixCSR<ValueType>::HostMatrixCSR()
     {
@@ -73,6 +74,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     HostMatrixCSR<ValueType>::HostMatrixCSR(const Rocalution_Backend_Descriptor& local_backend)
@@ -151,24 +153,30 @@ namespace rocalution
             if((std::abs(this->nnz_) == std::numeric_limits<int64_t>::infinity()) || // inf
                (this->nnz_ != this->nnz_))
             { // NaN
+                // LCOV_EXCL_START
                 LOG_VERBOSE_INFO(2, "*** error: Matrix CSR:Check - problems with matrix nnz");
                 return false;
+                // LCOV_EXCL_STOP
             }
 
             // nrow
             if((std::abs(this->nrow_) == std::numeric_limits<int>::infinity()) || // inf
                (this->nrow_ != this->nrow_))
             { // NaN
+                // LCOV_EXCL_START
                 LOG_VERBOSE_INFO(2, "*** error: Matrix CSR:Check - problems with matrix nrow");
                 return false;
+                // LCOV_EXCL_STOP
             }
 
             // ncol
             if((std::abs(this->ncol_) == std::numeric_limits<int>::infinity()) || // inf
                (this->ncol_ != this->ncol_))
             { // NaN
+                // LCOV_EXCL_START
                 LOG_VERBOSE_INFO(2, "*** error: Matrix CSR:Check - problems with matrix ncol");
                 return false;
+                // LCOV_EXCL_STOP
             }
 
             for(int ai = 0; ai < this->nrow_ + 1; ++ai)
@@ -176,10 +184,12 @@ namespace rocalution
                 PtrType row = this->mat_.row_offset[ai];
                 if((row < 0) || (row > this->nnz_))
                 {
+                    // LCOV_EXCL_START
                     LOG_VERBOSE_INFO(
                         2,
                         "*** error: Matrix CSR:Check - problems with matrix row offset pointers");
                     return false;
+                    // LCOV_EXCL_STOP
                 }
             }
 
@@ -195,25 +205,31 @@ namespace rocalution
 
                     if((col < 0) || (col > this->ncol_))
                     {
+                        // LCOV_EXCL_START
                         LOG_VERBOSE_INFO(
                             2, "*** error: Matrix CSR:Check - problems with matrix col values");
                         return false;
+                        // LCOV_EXCL_STOP
                     }
 
                     if(col == prev_col)
                     {
+                        // LCOV_EXCL_START
                         LOG_VERBOSE_INFO(2,
                                          "*** error: Matrix CSR:Check - problems with matrix col "
                                          "values - the matrix has duplicated column entries");
                         return false;
+                        // LCOV_EXCL_STOP
                     }
 
                     ValueType val = this->mat_.val[aj];
                     if((val == std::numeric_limits<ValueType>::infinity()) || (val != val))
                     {
+                        // LCOV_EXCL_START
                         LOG_VERBOSE_INFO(
                             2, "*** error: Matrix CSR:Check - problems with matrix values");
                         return false;
+                        // LCOV_EXCL_STOP
                     }
 
                     if((aj > this->mat_.row_offset[ai]) && (s >= col))
@@ -1498,8 +1514,10 @@ namespace rocalution
 
         if(!status)
         {
+            // LCOV_EXCL_START
             LOG_INFO("ItLUAnalyse() failed");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         status = host_csritsv_buffer_size(host_sparse_operation_none,
@@ -1515,8 +1533,10 @@ namespace rocalution
 
         if(!status)
         {
+            // LCOV_EXCL_START
             LOG_INFO("ItLUAnalyse() failed");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         buffer_size = std::max(L_buffer_size, U_buffer_size);
@@ -1615,8 +1635,10 @@ namespace rocalution
 
             if(!status)
             {
+                // LCOV_EXCL_START
                 LOG_INFO("ItLUSolve() failed to solve L");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
 
             // Solve U
@@ -1640,8 +1662,10 @@ namespace rocalution
 
             if(!status)
             {
+                // LCOV_EXCL_START
                 LOG_INFO("ItLUSolve() failed to solve U");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
         }
 
@@ -1681,8 +1705,10 @@ namespace rocalution
 
         if(!status)
         {
+            // LCOV_EXCL_START
             LOG_INFO("ItLLAnalyse() failed");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         status = host_csritsv_buffer_size(host_sparse_operation_transpose,
@@ -1698,8 +1724,10 @@ namespace rocalution
 
         if(!status)
         {
+            // LCOV_EXCL_START
             LOG_INFO("ItLLAnalyse() failed");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         buffer_size = std::max(L_buffer_size, Lt_buffer_size);
@@ -1798,8 +1826,10 @@ namespace rocalution
 
             if(!status)
             {
+                // LCOV_EXCL_START
                 LOG_INFO("ItLLSolve() failed");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
 
             // Solve Lt
@@ -1823,8 +1853,10 @@ namespace rocalution
 
             if(!status)
             {
+                // LCOV_EXCL_START
                 LOG_INFO("ItLLSolve() failed");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
         }
 
@@ -1871,8 +1903,10 @@ namespace rocalution
 
         if(!status)
         {
+            // LCOV_EXCL_START
             LOG_INFO("ItLAnalyse() failed");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // Check buffer size
@@ -1958,8 +1992,10 @@ namespace rocalution
 
             if(!status)
             {
+                // LCOV_EXCL_START
                 LOG_INFO("ItLSolve() failed");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
         }
 
@@ -1995,8 +2031,10 @@ namespace rocalution
 
         if(!status)
         {
+            // LCOV_EXCL_START
             LOG_INFO("ItUAnalyse() failed");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // Check buffer size
@@ -2082,8 +2120,10 @@ namespace rocalution
 
             if(!status)
             {
+                // LCOV_EXCL_START
                 LOG_INFO("ItUSolve() failed");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
         }
 
@@ -2275,11 +2315,13 @@ namespace rocalution
 
                 if(col_tmp == NULL || val_tmp == NULL)
                 {
+                    // LCOV_EXCL_START
                     free(col);
                     free(val);
 
                     LOG_INFO("ILUTFactorize failed on realloc");
                     FATAL_ERROR(__FILE__, __LINE__);
+                    // LCOV_EXCL_STOP
                 }
                 else
                 {
@@ -2404,8 +2446,10 @@ namespace rocalution
                 // Check for numeric zero
                 if(inv_diag == static_cast<ValueType>(0))
                 {
+                    // LCOV_EXCL_START
                     LOG_INFO("IC breakdown: division by zero");
                     FATAL_ERROR(__FILE__, __LINE__);
+                    // LCOV_EXCL_STOP
                 }
 
                 inv_diag = static_cast<ValueType>(1) / inv_diag;
@@ -2429,9 +2473,11 @@ namespace rocalution
 
             if(!has_diag)
             {
+                // LCOV_EXCL_START
                 // Structural zero
                 LOG_INFO("IC breakdown: structural zero diagonal");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
 
             // Process diagonal entry
@@ -2441,8 +2487,10 @@ namespace rocalution
             // Check for numerical zero
             if(diag_entry == static_cast<ValueType>(0))
             {
+                // LCOV_EXCL_START
                 LOG_INFO("IC breakdown: division by zero");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
 
             // Store inverse diagonal entry
@@ -5249,6 +5297,7 @@ namespace rocalution
         return *ti;
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     bool HostMatrixCSR<ValueType>::AMGExtractBoundaryState(
         const BaseVector<PtrType>&   bnd_csr_row_ptr,
@@ -5335,6 +5384,7 @@ namespace rocalution
 
         return true;
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     bool HostMatrixCSR<ValueType>::AMGPMISFindMaxNeighbourNode(
@@ -5976,6 +6026,7 @@ namespace rocalution
         // Ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             assert(cast_gst != NULL);
             assert(cast_pg != NULL);
 
@@ -5988,6 +6039,7 @@ namespace rocalution
 
             // Number of ghost rows is identical to interior
             cast_pg->nrow_ = this->nrow_;
+            // LCOV_EXCL_STOP
         }
 
         // Count number of entries in interior prolong
@@ -6032,6 +6084,7 @@ namespace rocalution
 
             if(global == true)
             {
+                // LCOV_EXCL_START
                 PtrType gst_row_begin = cast_gst->mat_.row_offset[i];
                 PtrType gst_row_end   = cast_gst->mat_.row_offset[i + 1];
 
@@ -6063,6 +6116,7 @@ namespace rocalution
                 }
 
                 cast_pg->mat_.row_offset[i + 1] = gst_set.size();
+                // LCOV_EXCL_STOP
             }
 
             cast_pi->mat_.row_offset[i + 1] = int_set.size();
@@ -6132,6 +6186,7 @@ namespace rocalution
         // Once again for the ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             assert(cast_gst != NULL);
             assert(cast_pg != NULL);
             assert(cast_glo != NULL);
@@ -6154,6 +6209,7 @@ namespace rocalution
             set_to_zero_host(cast_pg->nnz_, cast_pg->mat_.val);
 
             cast_glo->Allocate(cast_pg->nnz_);
+            // LCOV_EXCL_STOP
         }
 
         // Fill the interpolation matrix.
@@ -6184,6 +6240,7 @@ namespace rocalution
 
             if(global == true)
             {
+                // LCOV_EXCL_START
                 for(PtrType j = cast_gst->mat_.row_offset[i]; j < cast_gst->mat_.row_offset[i + 1];
                     ++j)
                 {
@@ -6199,6 +6256,7 @@ namespace rocalution
                         }
                     }
                 }
+                // LCOV_EXCL_STOP
             }
 
             dia = static_cast<ValueType>(1) / dia;
@@ -6259,6 +6317,7 @@ namespace rocalution
             }
             if(global == true)
             {
+                // LCOV_EXCL_START
                 PtrType pg_row_begin = cast_pg->mat_.row_offset[i];
                 PtrType pg_row_end   = pg_row_begin;
 
@@ -6314,6 +6373,7 @@ namespace rocalution
                     cast_glo->vec_[pg_row_end]    = it->first;
                     ++pg_row_end;
                 }
+                // LCOV_EXCL_STOP
             }
 
             for(auto it = int_table.begin(); it != int_table.end(); it++)
@@ -6368,6 +6428,7 @@ namespace rocalution
         // Ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             assert(cast_gst != NULL);
             assert(cast_pg != NULL);
 
@@ -6380,6 +6441,7 @@ namespace rocalution
 
             // Number of ghost rows is identical to interior
             cast_pg->nrow_ = this->nrow_;
+            // LCOV_EXCL_STOP
         }
 
         // Count number of entries in interior prolong
@@ -6460,6 +6522,7 @@ namespace rocalution
         // Once again for the ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             assert(cast_gst != NULL);
             assert(cast_pg != NULL);
             assert(cast_glo != NULL);
@@ -6482,6 +6545,7 @@ namespace rocalution
             set_to_zero_host(cast_pg->nnz_, cast_pg->mat_.val);
 
             cast_glo->Allocate(cast_pg->nnz_);
+            // LCOV_EXCL_STOP
         }
 
         // Count number of entries in interior prolong
@@ -7541,6 +7605,7 @@ namespace rocalution
         // Ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             assert(cast_gst != NULL);
             assert(cast_pg != NULL);
 
@@ -7552,6 +7617,7 @@ namespace rocalution
 
             // Number of ghost rows is identical to interior
             cast_pg->nrow_ = this->nrow_;
+            // LCOV_EXCL_STOP
         }
 
 #ifdef _OPENMP
@@ -7713,10 +7779,12 @@ namespace rocalution
         // Ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             assert(cast_l2g != NULL);
             assert(cast_gst != NULL);
             assert(cast_pg != NULL);
             assert(cast_glo != NULL);
+            // LCOV_EXCL_STOP
         }
 
         // Exclusive sum to obtain row offset pointers of P
@@ -7746,6 +7814,7 @@ namespace rocalution
         // Once again for the ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             for(int i = this->nrow_; i > 0; --i)
             {
                 cast_pg->mat_.row_offset[i] = cast_pg->mat_.row_offset[i - 1];
@@ -7765,6 +7834,7 @@ namespace rocalution
             allocate_host(cast_pg->nnz_, &cast_pg->mat_.val);
 
             cast_glo->Allocate(cast_pg->nnz_);
+            // LCOV_EXCL_STOP
         }
 
 #ifdef _OPENMP
@@ -7944,6 +8014,7 @@ namespace rocalution
         return true;
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     bool HostMatrixCSR<ValueType>::RSExtPIBoundaryNnz(const BaseVector<int>&       boundary,
                                                       const BaseVector<int>&       CFmap,
@@ -8115,6 +8186,7 @@ namespace rocalution
 
         return true;
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     bool HostMatrixCSR<ValueType>::RSExtPIProlongNnz(int64_t                    global_column_begin,
@@ -8163,6 +8235,7 @@ namespace rocalution
         // Ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             assert(cast_l2g != NULL);
             assert(cast_gst != NULL);
             assert(cast_ptr != NULL);
@@ -8177,6 +8250,7 @@ namespace rocalution
 
             // Number of ghost rows is identical to interior
             cast_pg->nrow_ = this->nrow_;
+            // LCOV_EXCL_STOP
         }
 
 #ifdef _OPENMP
@@ -8455,6 +8529,7 @@ namespace rocalution
         // Ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             assert(cast_l2g != NULL);
             assert(cast_gst != NULL);
             assert(cast_ptr != NULL);
@@ -8464,6 +8539,7 @@ namespace rocalution
             assert(cast_ext_val != NULL);
             assert(cast_pg != NULL);
             assert(cast_glo != NULL);
+            // LCOV_EXCL_STOP
         }
 
         // Exclusive sum to obtain row offset pointers of P
@@ -8493,6 +8569,7 @@ namespace rocalution
         // Once again for the ghost part
         if(global == true)
         {
+            // LCOV_EXCL_START
             for(int i = this->nrow_; i > 0; --i)
             {
                 cast_pg->mat_.row_offset[i] = cast_pg->mat_.row_offset[i - 1];
@@ -8512,6 +8589,7 @@ namespace rocalution
             allocate_host(cast_pg->nnz_, &cast_pg->mat_.val);
 
             cast_glo->Allocate(cast_pg->nnz_);
+            // LCOV_EXCL_STOP
         }
 
         // Extract diagonal matrix entries
@@ -10523,6 +10601,7 @@ namespace rocalution
         return true;
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     bool HostMatrixCSR<ValueType>::ExtractGlobalColumnIndices(int     ncol,
                                                               int64_t global_offset,
@@ -11490,6 +11569,8 @@ namespace rocalution
 
         return true;
     }
+
+    // LCOV_EXCL_STOP
 
     template class HostMatrixCSR<double>;
     template class HostMatrixCSR<float>;

--- a/src/base/host/host_matrix_dense.cpp
+++ b/src/base/host/host_matrix_dense.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,6 +44,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostMatrixDENSE<ValueType>::HostMatrixDENSE()
     {
@@ -51,6 +52,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     HostMatrixDENSE<ValueType>::HostMatrixDENSE(const Rocalution_Backend_Descriptor& local_backend)

--- a/src/base/host/host_matrix_dia.cpp
+++ b/src/base/host/host_matrix_dia.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,6 +42,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostMatrixDIA<ValueType>::HostMatrixDIA()
     {
@@ -49,6 +50,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STop
 
     template <typename ValueType>
     HostMatrixDIA<ValueType>::HostMatrixDIA(const Rocalution_Backend_Descriptor& local_backend)

--- a/src/base/host/host_matrix_ell.cpp
+++ b/src/base/host/host_matrix_ell.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,6 +42,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostMatrixELL<ValueType>::HostMatrixELL()
     {
@@ -49,6 +50,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     HostMatrixELL<ValueType>::HostMatrixELL(const Rocalution_Backend_Descriptor& local_backend)

--- a/src/base/host/host_matrix_hyb.cpp
+++ b/src/base/host/host_matrix_hyb.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,6 +42,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostMatrixHYB<ValueType>::HostMatrixHYB()
     {
@@ -49,6 +50,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     HostMatrixHYB<ValueType>::HostMatrixHYB(const Rocalution_Backend_Descriptor& local_backend)

--- a/src/base/host/host_matrix_mcsr.cpp
+++ b/src/base/host/host_matrix_mcsr.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,6 +43,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostMatrixMCSR<ValueType>::HostMatrixMCSR()
     {
@@ -50,6 +51,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     HostMatrixMCSR<ValueType>::HostMatrixMCSR(const Rocalution_Backend_Descriptor& local_backend)

--- a/src/base/host/host_stencil_laplace2d.cpp
+++ b/src/base/host/host_stencil_laplace2d.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostStencilLaplace2D<ValueType>::HostStencilLaplace2D()
     {
@@ -47,6 +48,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     HostStencilLaplace2D<ValueType>::HostStencilLaplace2D(

--- a/src/base/host/host_vector.cpp
+++ b/src/base/host/host_vector.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,6 +54,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     HostVector<ValueType>::HostVector()
     {
@@ -61,6 +62,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     HostVector<ValueType>::HostVector(const Rocalution_Backend_Descriptor& local_backend)
@@ -97,16 +99,20 @@ namespace rocalution
                 if((std::abs(this->vec_[i]) == std::numeric_limits<ValueType>::infinity()) || // inf
                    (this->vec_[i] != this->vec_[i]))
                 { // NaN
+                    // LCOV_EXCL_START
                     LOG_VERBOSE_INFO(2, "*** error: Vector:Check - problems with vector data");
                     return false;
+                    // LCOV_EXCL_STOP
                 }
             }
 
             if((std::abs(this->size_) == std::numeric_limits<int64_t>::infinity()) || // inf
                (this->size_ != this->size_))
             { // NaN
+                // LCOV_EXCL_START
                 LOG_VERBOSE_INFO(2, "*** error: Vector:Check - problems with vector size");
                 return false;
+                // LCOV_EXCL_STOP
             }
         }
         else
@@ -128,8 +134,10 @@ namespace rocalution
             if(std::abs(this->size_) == std::numeric_limits<int64_t>::infinity())
             {
                 // inf
+                // LCOV_EXCL_START
                 LOG_VERBOSE_INFO(2, "*** error: Vector:Check - problems with vector size");
                 return false;
+                // LCOV_EXCL_STOP
             }
         }
         else
@@ -254,12 +262,14 @@ namespace rocalution
         vec->CopyFrom(*this);
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void HostVector<ValueType>::CopyFromFloat(const BaseVector<float>& vec)
     {
         LOG_INFO("Mixed precision for non-complex to complex casting is not allowed");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <>
     void HostVector<double>::CopyFromFloat(const BaseVector<float>& vec)
@@ -286,6 +296,7 @@ namespace rocalution
         }
         else
         {
+            // LCOV_EXCL_START
             LOG_INFO("No cross backend casting");
             FATAL_ERROR(__FILE__, __LINE__);
         }
@@ -297,6 +308,7 @@ namespace rocalution
         LOG_INFO("Mixed precision for non-complex to complex casting is not allowed");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <>
     void HostVector<float>::CopyFromDouble(const BaseVector<double>& vec)
@@ -323,8 +335,10 @@ namespace rocalution
         }
         else
         {
+            // LCOV_EXCL_START
             LOG_INFO("No cross backend casting");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -404,12 +418,14 @@ namespace rocalution
         }
     }
 
+    // LCOV_EXCL_START
     template <>
     void HostVector<bool>::SetRandomNormal(unsigned long long seed, bool mean, bool var)
     {
         LOG_INFO("What is bool HostVector<ValueType>::SetRandomNormal(void) const?");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     void HostVector<ValueType>::ReadFileASCII(const std::string& filename)
@@ -424,8 +440,10 @@ namespace rocalution
 
         if(!file.is_open())
         {
+            // LCOV_EXCL_START
             LOG_INFO("Can not open vector file [read]:" << filename);
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         this->Clear();
@@ -463,8 +481,10 @@ namespace rocalution
 
         if(!file.is_open())
         {
+            // LCOV_EXCL_START
             LOG_INFO("Can not open vector file [write]:" << filename);
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         file.setf(std::ios::scientific);
@@ -488,8 +508,10 @@ namespace rocalution
 
         if(!in.is_open())
         {
+            // LCOV_EXCL_START
             LOG_INFO("ReadFileBinary: filename=" << filename << "; cannot open file");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // Header
@@ -498,8 +520,10 @@ namespace rocalution
 
         if(header != "#rocALUTION binary vector file")
         {
+            // LCOV_EXCL_START
             LOG_INFO("ReadFileBinary: filename=" << filename << " is not a rocALUTION vector");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // rocALUTION version
@@ -554,15 +578,19 @@ namespace rocalution
         }
         else
         {
+            // LCOV_EXCL_START
             LOG_INFO("ReadFileBinary: filename=" << filename << "; internal error");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // Check ifstream status
         if(!in)
         {
+            // LCOV_EXCL_START
             LOG_INFO("ReadFileBinary: filename=" << filename << "; could not read from file");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         in.close();
@@ -579,8 +607,10 @@ namespace rocalution
 
         if(!out.is_open())
         {
+            // LCOV_EXCL_START
             LOG_INFO("WriteFileBinary: filename=" << filename << "; cannot open file");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // Header
@@ -615,15 +645,19 @@ namespace rocalution
         }
         else // TODO complex
         {
+            // LCOV_EXCL_START
             LOG_INFO("WriteFileBinary: filename=" << filename << "; internal error");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // Check ofstream status
         if(!out)
         {
+            // LCOV_EXCL_START
             LOG_INFO("ReadFileBinary: filename=" << filename << "; could not write to file");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         out.close();
@@ -760,12 +794,14 @@ namespace rocalution
         }
     }
 
+    // LCOV_EXCL_START
     template <>
     void HostVector<bool>::Scale(bool alpha)
     {
         LOG_INFO("What is bool HostVector<ValueType>::Scale(void) const?");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     ValueType HostVector<ValueType>::Dot(const BaseVector<ValueType>& x) const
@@ -970,12 +1006,14 @@ namespace rocalution
         return std::complex<double>(asum_real, asum_imag);
     }
 
+    // LCOV_EXCL_START
     template <>
     bool HostVector<bool>::Asum(void) const
     {
         LOG_INFO("What is bool HostVector<ValueType>::Asum(void) const?");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     int64_t HostVector<ValueType>::Amax(ValueType& value) const
@@ -1008,12 +1046,14 @@ namespace rocalution
         return index;
     }
 
+    // LCOV_EXCL_START
     template <>
     int64_t HostVector<bool>::Amax(bool& value) const
     {
         LOG_INFO("What is int64_t HostVector<ValueType>::Amax(void) const?");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     ValueType HostVector<ValueType>::Norm(void) const
@@ -1075,6 +1115,7 @@ namespace rocalution
         return res;
     }
 
+    // LCOV_EXCL_START
     template <>
     int HostVector<int>::Norm(void) const
     {
@@ -1095,6 +1136,7 @@ namespace rocalution
         LOG_INFO("What is bool HostVector<ValueType>::Norm(void) const?");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     ValueType HostVector<ValueType>::Reduce(void) const
@@ -1246,12 +1288,14 @@ namespace rocalution
         }
     }
 
+    // LCOV_EXCL_START
     template <>
     void HostVector<bool>::PointWiseMult(const BaseVector<bool>& x)
     {
         LOG_INFO("What is bool HostVector<ValueType>::PointWiseMult() const?");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     void HostVector<ValueType>::PointWiseMult(const BaseVector<ValueType>& x,
@@ -1276,12 +1320,14 @@ namespace rocalution
         }
     }
 
+    // LCOV_EXCL_START
     template <>
     void HostVector<bool>::PointWiseMult(const BaseVector<bool>& x, const BaseVector<bool>& y)
     {
         LOG_INFO("What is bool HostVector<ValueType>::PointWiseMult() const?");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     void HostVector<ValueType>::CopyFrom(const BaseVector<ValueType>& src,
@@ -1582,6 +1628,7 @@ namespace rocalution
         }
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void HostVector<ValueType>::ExtractCoarseMapping(
         int64_t start, int64_t end, const int* index, int nc, int* size, int* map) const
@@ -1589,6 +1636,7 @@ namespace rocalution
         LOG_INFO("double/float HostVector<ValueType>::ExtractCoarseMapping() not available");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <>
     void HostVector<int>::ExtractCoarseMapping(
@@ -1631,6 +1679,7 @@ namespace rocalution
         *size = ind;
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void HostVector<ValueType>::ExtractCoarseBoundary(
         int64_t start, int64_t end, const int* index, int nc, int* size, int* boundary) const
@@ -1638,6 +1687,7 @@ namespace rocalution
         LOG_INFO("double/float HostVector<ValueType>::ExtractCoarseBoundary() not available");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <>
     void HostVector<int>::ExtractCoarseBoundary(
@@ -1785,6 +1835,7 @@ namespace rocalution
         }
     }
 
+    // LCOV_EXCL_START
     template <>
     void HostVector<std::complex<float>>::Sort(BaseVector<std::complex<float>>* sorted,
                                                BaseVector<int>*                 perm) const
@@ -1800,6 +1851,7 @@ namespace rocalution
         LOG_INFO("HostVector::Sort(), how to sort complex numbers?");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template class HostVector<bool>;
     template class HostVector<double>;

--- a/src/base/local_matrix.cpp
+++ b/src/base/local_matrix.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -119,6 +119,8 @@ namespace rocalution
         {
             bool err = this->matrix_->Zeros();
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::Zeros() failed");
@@ -160,6 +162,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -1276,6 +1280,8 @@ namespace rocalution
 
         bool err = this->matrix_->ReadFileMTX(filename);
 
+        // LCOV_EXCL_START
+
         if((err == false) && (this->is_host_() == true) && (this->GetFormat() == COO))
         {
             LOG_INFO("Execution of LocalMatrix::ReadFileMTX() failed");
@@ -1310,6 +1316,7 @@ namespace rocalution
 
             this->ConvertTo(format, blockdim);
         }
+        // LCOV_EXCL_STOP
         else
         {
             this->Sort();
@@ -1337,6 +1344,8 @@ namespace rocalution
 
         bool err = this->matrix_->WriteFileMTX(filename);
 
+        // LCOV_EXCL_START
+
         if((err == false) && (this->is_host_() == true) && (this->GetFormat() == COO))
         {
             LOG_INFO("Execution of LocalMatrix::WriteFileMTX() failed");
@@ -1362,9 +1371,12 @@ namespace rocalution
             }
         }
 
+        // LCOV_EXCL_STOP
+
         LOG_INFO("WriteFileMTX: filename=" << filename << "; done");
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void LocalMatrix<ValueType>::ReadFileCSR(const std::string& filename)
     {
@@ -1418,6 +1430,8 @@ namespace rocalution
         LOG_INFO("ReadFileCSR: filename=" << filename << "; done");
     }
 
+    // LCOV_EXCL_STOP
+
     template <typename ValueType>
     void LocalMatrix<ValueType>::ReadFileRSIO(const std::string& filename,
                                               bool               maintain_initial_format)
@@ -1446,8 +1460,10 @@ namespace rocalution
 
         if(status != rocsparseio_status_success)
         {
+            // LCOV_EXCL_START
             LOG_INFO("Execution of LocalMatrix::ReadFileRSIO() failed: cannot open file");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // Get format
@@ -1456,8 +1472,10 @@ namespace rocalution
 
         if(status != rocsparseio_status_success)
         {
+            // LCOV_EXCL_START
             LOG_INFO("Execution of LocalMatrix::ReadFileRSIO() failed: cannot read format");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // Close file
@@ -1465,8 +1483,10 @@ namespace rocalution
 
         if(status != rocsparseio_status_success)
         {
+            // LCOV_EXCL_START
             LOG_INFO("Execution of LocalMatrix::ReadFileRSIO() failed: cannot close file");
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         switch(rsio_format)
@@ -1519,19 +1539,23 @@ namespace rocalution
             this->ConvertToMCSR();
             break;
         }
+        // LCOV_EXCL_START
         case rocsparseio_format_dense_vector:
         {
             LOG_INFO("Execution of LocalMatrix::ReadFileRSIO() failed: unknown format");
             FATAL_ERROR(__FILE__, __LINE__);
         }
+            // LCOV_EXCL_STOP
         }
 
         // Read in matrix
         if(!this->matrix_->ReadFileRSIO(filename))
         {
+            // LCOV_EXCL_START
             LOG_INFO("Execution of LocalMatrix::ReadFileRSIO() failed");
             this->Info();
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         // Move back to initial backend
@@ -1564,6 +1588,7 @@ namespace rocalution
         LOG_INFO("ReadFileRSIO: filename=" << filename << "; done");
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void LocalMatrix<ValueType>::WriteFileCSR(const std::string& filename) const
     {
@@ -1604,6 +1629,7 @@ namespace rocalution
 
         LOG_INFO("WriteFileCSR: filename=" << filename << "; done");
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     void LocalMatrix<ValueType>::WriteFileRSIO(const std::string& filename) const
@@ -1617,6 +1643,8 @@ namespace rocalution
 #endif
 
         bool err = this->matrix_->WriteFileRSIO(filename);
+
+        // LCOV_EXCL_START
 
         if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
         {
@@ -1652,6 +1680,8 @@ namespace rocalution
                 FATAL_ERROR(__FILE__, __LINE__);
             }
         }
+
+        // LCOV_EXCL_STOP
 
         LOG_INFO("WriteFileRSIO: filename=" << filename << "; done");
     }
@@ -2105,9 +2135,11 @@ namespace rocalution
                     // If CSR conversion fails too, exit with error
                     if(new_mat->ConvertFrom(*this->matrix_host_) == false)
                     {
+                        // LCOV_EXCL_START
                         LOG_INFO("Unsupported (on host) conversion to CSR");
                         this->Info();
                         FATAL_ERROR(__FILE__, __LINE__);
+                        // LCOV_EXCL_STOP
                     }
                 }
 
@@ -2231,6 +2263,8 @@ namespace rocalution
 
             bool err = this->matrix_->ExtractDiagonal(vec_diag->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::ExtractDiagonal() failed");
@@ -2270,6 +2304,8 @@ namespace rocalution
                     vec_diag->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -2297,6 +2333,8 @@ namespace rocalution
                                    std::min(this->GetLocalM(), this->GetLocalN()));
 
             bool err = this->matrix_->ExtractInverseDiagonal(vec_inv_diag->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -2338,6 +2376,8 @@ namespace rocalution
                     vec_inv_diag->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -2391,6 +2431,8 @@ namespace rocalution
                                                   static_cast<int>(col_size),
                                                   mat->matrix_);
         }
+
+        // LCOV_EXCL_START
 
         if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
         {
@@ -2453,6 +2495,8 @@ namespace rocalution
                                  "the host due to size = 1");
             }
         }
+
+        // LCOV_EXCL_STOP
 
         std::ostringstream row_begin;
         std::ostringstream row_end;
@@ -2561,6 +2605,8 @@ namespace rocalution
                 err = this->matrix_->ExtractU(U->matrix_);
             }
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::ExtractU() failed");
@@ -2612,6 +2658,8 @@ namespace rocalution
                     U->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -2646,6 +2694,8 @@ namespace rocalution
             {
                 err = this->matrix_->ExtractL(L->matrix_);
             }
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -2698,6 +2748,8 @@ namespace rocalution
                     L->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -2750,6 +2802,8 @@ namespace rocalution
         {
             bool err = this->matrix_->LUSolve(*in.vector_, out->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::LUSolve() failed");
@@ -2797,6 +2851,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -2845,6 +2901,8 @@ namespace rocalution
         {
             bool err = this->matrix_->LLSolve(*in.vector_, out->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::LLSolve() failed");
@@ -2886,6 +2944,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -2914,6 +2974,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->LLSolve(*in.vector_, *inv_diag.vector_, out->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -2961,6 +3023,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -3009,6 +3073,8 @@ namespace rocalution
         {
             bool err = this->matrix_->LSolve(*in.vector_, out->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::LSolve() failed");
@@ -3050,6 +3116,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -3098,6 +3166,8 @@ namespace rocalution
         {
             bool err = this->matrix_->USolve(*in.vector_, out->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::USolve() failed");
@@ -3139,6 +3209,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -3198,6 +3270,8 @@ namespace rocalution
             bool err
                 = this->matrix_->ItLUSolve(max_iter, tolerance, use_tol, *in.vector_, out->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::ItLUSolve() failed");
@@ -3255,6 +3329,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -3314,6 +3390,8 @@ namespace rocalution
             bool err
                 = this->matrix_->ItLLSolve(max_iter, tolerance, use_tol, *in.vector_, out->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::ItLLSolve() failed");
@@ -3371,6 +3449,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -3417,6 +3497,8 @@ namespace rocalution
         {
             bool err = this->matrix_->ItLLSolve(
                 max_iter, tolerance, use_tol, *in.vector_, *inv_diag.vector_, out->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -3474,6 +3556,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -3534,6 +3618,8 @@ namespace rocalution
             bool err
                 = this->matrix_->ItLSolve(max_iter, tolerance, use_tol, *in.vector_, out->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::ItLSolve() failed");
@@ -3590,6 +3676,7 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -3650,6 +3737,8 @@ namespace rocalution
             bool err
                 = this->matrix_->ItUSolve(max_iter, tolerance, use_tol, *in.vector_, out->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::ItUSolve() failed");
@@ -3704,6 +3793,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -3719,6 +3810,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ILU0Factorize();
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -3761,6 +3854,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -3790,6 +3885,8 @@ namespace rocalution
         {
             bool err
                 = this->matrix_->ItILU0Factorize(alg, option, max_iter, tolerance, niter, history);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->GetFormat() == CSR) && (this->is_host_() == true))
             {
@@ -3835,6 +3932,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -3857,6 +3956,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ILUTFactorize(t, maxrow);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -3899,6 +4000,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -3933,6 +4036,8 @@ namespace rocalution
                     structure.SymbolicPower(p + 1);
 
                     bool err = this->matrix_->ILUpFactorizeNumeric(p, *structure.matrix_);
+
+                    // LCOV_EXCL_START
 
                     if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
                     {
@@ -3980,6 +4085,8 @@ namespace rocalution
                         }
                     }
 
+                    // LCOV_EXCL_STOP
+
                     // without control levels
                 }
                 else
@@ -3991,6 +4098,8 @@ namespace rocalution
                     this->MatrixAdd(values);
 
                     bool err = this->matrix_->ILU0Factorize();
+
+                    // LCOV_EXCL_START
 
                     if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
                     {
@@ -4035,6 +4144,8 @@ namespace rocalution
                             this->MoveToAccelerator();
                         }
                     }
+
+                    // LCOV_EXCL_STOP
                 }
             }
         }
@@ -4063,6 +4174,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ICFactorize(inv_diag->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -4107,6 +4220,8 @@ namespace rocalution
                     inv_diag->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -4141,6 +4256,8 @@ namespace rocalution
             permutation->CloneBackend(*this);
 
             bool err = this->matrix_->MultiColoring(num_colors, size_colors, permutation->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -4183,6 +4300,8 @@ namespace rocalution
                     permutation->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -4212,6 +4331,8 @@ namespace rocalution
             permutation->CloneBackend(*this);
 
             bool err = this->matrix_->MaximalIndependentSet(size, permutation->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -4255,6 +4376,8 @@ namespace rocalution
                     permutation->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -4282,6 +4405,8 @@ namespace rocalution
             permutation->Allocate(vec_perm_name, this->GetLocalM());
 
             bool err = this->matrix_->ZeroBlockPermutation(size, permutation->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -4325,6 +4450,8 @@ namespace rocalution
                     permutation->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -4345,6 +4472,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Householder(idx, beta, vec->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == DENSE))
             {
@@ -4385,6 +4514,8 @@ namespace rocalution
                     vec->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -4400,6 +4531,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->QRDecompose();
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == DENSE))
             {
@@ -4442,6 +4575,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -4467,6 +4602,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->QRSolve(*in.vector_, out->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == DENSE))
             {
@@ -4511,6 +4648,8 @@ namespace rocalution
                     out->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -4534,6 +4673,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Permute(*permutation.vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -4578,6 +4719,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -4605,6 +4748,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->PermuteBackward(*permutation.vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == COO))
             {
@@ -4650,6 +4795,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -4676,6 +4823,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->CMK(permutation->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -4716,6 +4865,8 @@ namespace rocalution
                     permutation->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
         std::string vec_name      = "CMK permutation of " + this->object_name_;
@@ -4745,6 +4896,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->RCMK(permutation->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -4786,6 +4939,8 @@ namespace rocalution
                     permutation->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
         std::string vec_name      = "RCMK permutation of " + this->object_name_;
@@ -4815,6 +4970,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ConnectivityOrder(permutation->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -4858,6 +5015,8 @@ namespace rocalution
                     permutation->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
         std::string vec_name      = "ConnectivityOrder permutation of " + this->object_name_;
@@ -4878,6 +5037,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->SymbolicPower(p);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -4920,6 +5081,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -4949,6 +5112,8 @@ namespace rocalution
 #endif
 
         bool err = this->matrix_->MatrixAdd(*mat.matrix_, alpha, beta, structure);
+
+        // LCOV_EXCL_START
 
         if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
         {
@@ -4992,6 +5157,8 @@ namespace rocalution
             }
         }
 
+        // LCOV_EXCL_STOP
+
 #ifdef DEBUG_MODE
         this->Check();
 #endif
@@ -5009,6 +5176,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Gershgorin(lambda_min, lambda_max);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5045,6 +5214,8 @@ namespace rocalution
                         2, "*** warning: LocalMatrix::Gershgorin() is performed on the host");
                 }
             }
+
+            // LCOV_EXCL_STop
         }
     }
 
@@ -5060,6 +5231,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Scale(alpha);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5102,6 +5275,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5121,6 +5296,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ScaleDiagonal(alpha);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5163,6 +5340,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5182,6 +5361,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ScaleOffDiagonal(alpha);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5225,6 +5406,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5244,6 +5427,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->AddScalar(alpha);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5286,6 +5471,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5305,6 +5492,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->AddScalarDiagonal(alpha);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5349,6 +5538,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5368,6 +5559,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->AddScalarOffDiagonal(alpha);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5412,6 +5605,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5460,6 +5655,8 @@ namespace rocalution
 
         bool err = this->matrix_->MatMatMult(*A.matrix_, *B.matrix_);
 
+        // LCOV_EXCL_START
+
         if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
         {
             LOG_INFO("Computation of LocalMatrix::MatMatMult() failed");
@@ -5505,6 +5702,8 @@ namespace rocalution
                 this->MoveToAccelerator();
             }
         }
+
+        // LCOV_EXCL_STOP
 
 #ifdef DEBUG_MODE
         this->Check();
@@ -5611,6 +5810,8 @@ namespace rocalution
         {
             bool err = this->matrix_->DiagonalMatrixMultR(*diag.vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::DiagonalMatrixMultR() failed");
@@ -5656,6 +5857,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5686,6 +5889,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->DiagonalMatrixMultL(*diag.vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5732,6 +5937,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5753,6 +5960,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Compress(drop_off);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5795,6 +6004,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5814,6 +6025,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Transpose();
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5856,6 +6069,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5881,6 +6096,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Transpose(T->matrix_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5924,6 +6141,8 @@ namespace rocalution
                     T->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -5939,6 +6158,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Sort();
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -5983,6 +6204,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -6002,6 +6225,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Key(row_key, col_key, val_key);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -6038,9 +6263,12 @@ namespace rocalution
                     LOG_VERBOSE_INFO(2, "*** warning: LocalMatrix::Key() is performed on the host");
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void LocalMatrix<ValueType>::AMGConnect(ValueType eps, LocalVector<int>* connections) const
     {
@@ -6403,6 +6631,7 @@ namespace rocalution
         prolong->Check();
 #endif
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     void
@@ -6466,9 +6695,11 @@ namespace rocalution
 
             if((status == false) && (this->is_host_() == true))
             {
+                // LCOV_EXCL_START
                 LOG_INFO("Computation of LocalMatrix::AMGGreedyAggregate() failed");
                 this->Info();
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
 
             if(status == false)
@@ -6485,9 +6716,11 @@ namespace rocalution
                        *connections->vector_, aggregates->vector_, aggregate_root_nodes->vector_)
                    == false)
                 {
+                    // LCOV_EXCL_START
                     LOG_INFO("Computation of LocalMatrix::AMGGreedyAggregate() failed");
                     mat_host.Info();
                     FATAL_ERROR(__FILE__, __LINE__);
+                    // LCOV_EXCL_STOP
                 }
 
                 if(this->is_accel_() == true)
@@ -6730,6 +6963,7 @@ namespace rocalution
                                                                       prolong->matrix_,
                                                                       NULL);
 
+        // LCOV_EXCL_START
         if((err == false) && (csr_ptr->is_host_() == true) && (csr_ptr->GetFormat() == CSR))
         {
             LOG_INFO("Computation of LocalMatrix::ILU0Factorize() failed");
@@ -6819,6 +7053,7 @@ namespace rocalution
                 f2c_map.MoveToAccelerator();
                 prolong->MoveToAccelerator();
             }
+            // LCOV_EXCL_STOP
         }
         else
         {
@@ -6961,6 +7196,8 @@ namespace rocalution
         {
             bool err = this->matrix_->RSCoarsening(eps, CFmap->vector_, S->vector_);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::RSCoarsening() failed");
@@ -7003,6 +7240,8 @@ namespace rocalution
                     S->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
         std::string CFmap_name = "CF map of " + this->object_name_;
@@ -7343,6 +7582,8 @@ namespace rocalution
             bool err = this->matrix_->InitialPairwiseAggregation(
                 beta, nc, G->vector_, Gsize, rG, rGsize, ordering);
 
+            // LCOV_EXCL_START
+
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::InitialPairwiseAggregation() failed");
@@ -7387,6 +7628,8 @@ namespace rocalution
                     G->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -7431,6 +7674,7 @@ namespace rocalution
             bool err = this->matrix_->InitialPairwiseAggregation(
                 *mat.matrix_, beta, nc, G->vector_, Gsize, rG, rGsize, ordering);
 
+            // LCOV_EXCL_START
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
                 LOG_INFO("Computation of LocalMatrix::InitialPairwiseAggregation() failed");
@@ -7479,6 +7723,7 @@ namespace rocalution
                     G->MoveToAccelerator();
                 }
             }
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -7516,6 +7761,8 @@ namespace rocalution
         {
             bool err = this->matrix_->FurtherPairwiseAggregation(
                 beta, nc, G->vector_, Gsize, rG, rGsize, ordering);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -7561,6 +7808,8 @@ namespace rocalution
                     G->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -7604,6 +7853,8 @@ namespace rocalution
         {
             bool err = this->matrix_->FurtherPairwiseAggregation(
                 *mat.matrix_, beta, nc, G->vector_, Gsize, rG, rGsize, ordering);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -7652,6 +7903,8 @@ namespace rocalution
                     G->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -7695,6 +7948,8 @@ namespace rocalution
         {
             bool err = this->matrix_->CoarsenOperator(
                 Ac->matrix_, nrow, ncol, *G.vector_, Gsize, rG, rGsize);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -7749,6 +8004,8 @@ namespace rocalution
                     Ac->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -7777,6 +8034,8 @@ namespace rocalution
         {
             bool err = this->matrix_->CreateFromMap(
                 *map.vector_, static_cast<int>(n), static_cast<int>(m));
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -7823,6 +8082,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -7855,6 +8116,8 @@ namespace rocalution
 
         bool err = this->matrix_->CreateFromMap(
             *map.vector_, static_cast<int>(n), static_cast<int>(m), pro->matrix_);
+
+        // LCOV_EXCL_START
 
         if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
         {
@@ -7905,6 +8168,8 @@ namespace rocalution
             }
         }
 
+        // LCOV_EXCL_STOP
+
 #ifdef DEBUG_MODE
         this->Check();
         pro->Check();
@@ -7923,6 +8188,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->LUFactorize();
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == DENSE))
             {
@@ -7965,6 +8232,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -8001,6 +8270,8 @@ namespace rocalution
             {
                 err = this->matrix_->FSAI(power, NULL);
             }
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -8058,6 +8329,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -8079,6 +8352,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->SPAI();
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -8121,6 +8396,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -8140,6 +8417,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->Invert();
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == DENSE))
             {
@@ -8182,6 +8461,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -8207,6 +8488,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ReplaceColumnVector(idx, *vec.vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -8259,6 +8542,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -8285,6 +8570,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ExtractColumnVector(idx, vec->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -8328,6 +8615,8 @@ namespace rocalution
                     vec->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -8349,6 +8638,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ReplaceRowVector(idx, *vec.vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -8400,6 +8691,8 @@ namespace rocalution
                     this->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -8426,6 +8719,8 @@ namespace rocalution
         if(this->GetNnz() > 0)
         {
             bool err = this->matrix_->ExtractRowVector(idx, vec->vector_);
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -8468,9 +8763,12 @@ namespace rocalution
                     vec->MoveToAccelerator();
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void LocalMatrix<ValueType>::CompressAdd(const LocalVector<int64_t>&   l2g,
                                              const LocalVector<int64_t>&   global_ghost_col,
@@ -8565,6 +8863,8 @@ namespace rocalution
 #endif
     }
 
+    // LCOV_EXCL_STOP
+
     template <typename ValueType>
     void LocalMatrix<ValueType>::RSExtPIProlongNnz(int64_t                     global_column_begin,
                                                    int64_t                     global_column_end,
@@ -8630,6 +8930,8 @@ namespace rocalution
                 f2c->vector_,
                 prolong_int->matrix_,
                 (prolong_gst != NULL ? prolong_gst->matrix_ : NULL));
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -8724,6 +9026,8 @@ namespace rocalution
                     }
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE
@@ -8818,6 +9122,8 @@ namespace rocalution
                 prolong_int->matrix_,
                 (prolong_gst != NULL ? prolong_gst->matrix_ : NULL),
                 (global_ghost_col != NULL ? global_ghost_col->vector_ : NULL));
+
+            // LCOV_EXCL_START
 
             if((err == false) && (this->is_host_() == true) && (this->GetFormat() == CSR))
             {
@@ -8933,6 +9239,8 @@ namespace rocalution
                     }
                 }
             }
+
+            // LCOV_EXCL_STOP
         }
 
 #ifdef DEBUG_MODE

--- a/src/base/local_stencil.cpp
+++ b/src/base/local_stencil.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,6 +35,7 @@
 namespace rocalution
 {
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     LocalStencil<ValueType>::LocalStencil()
     {
@@ -46,6 +47,7 @@ namespace rocalution
         LOG_INFO("no default constructor");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <typename ValueType>
     LocalStencil<ValueType>::~LocalStencil()

--- a/src/base/local_vector.cpp
+++ b/src/base/local_vector.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1055,9 +1055,11 @@ namespace rocalution
 
             if((err == false) && (this->is_host_() == true))
             {
+                // LCOV_EXCL_START
                 LOG_INFO("Computation of LocalVector::Restriction() fail");
                 this->Info();
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
 
             if(err == false)
@@ -1072,9 +1074,11 @@ namespace rocalution
 
                 if(this->vector_->Restriction(*vec_fine_tmp.vector_, *map_tmp.vector_) == false)
                 {
+                    // LCOV_EXCL_START
                     LOG_INFO("Computation of LocalVector::Restriction() fail");
                     this->Info();
                     FATAL_ERROR(__FILE__, __LINE__);
+                    // LCOV_EXCL_STOP
                 }
 
                 LOG_VERBOSE_INFO(
@@ -1105,9 +1109,11 @@ namespace rocalution
 
             if((err == false) && (this->is_host_() == true))
             {
+                // LCOV_EXCL_START
                 LOG_INFO("Computation of LocalVector::Prolongation() fail");
                 this->Info();
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
 
             if(err == false)
@@ -1122,9 +1128,11 @@ namespace rocalution
 
                 if(this->vector_->Prolongation(*vec_coarse_tmp.vector_, *map_tmp.vector_) == false)
                 {
+                    // LCOV_EXCL_START
                     LOG_INFO("Computation of LocalVector::Prolongation() fail");
                     this->Info();
                     FATAL_ERROR(__FILE__, __LINE__);
+                    // LCOV_EXCL_STOP
                 }
 
                 LOG_VERBOSE_INFO(

--- a/src/base/operator.cpp
+++ b/src/base/operator.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -83,6 +83,7 @@ namespace rocalution
         return 0;
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void Operator<ValueType>::Transpose(void)
     {
@@ -145,6 +146,7 @@ namespace rocalution
         out->Info();
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template class Operator<double>;
     template class Operator<float>;

--- a/src/base/parallel_manager.cpp
+++ b/src/base/parallel_manager.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,8 @@
 #include "../utils/communicator.hpp"
 #include <mpi.h>
 #endif
+
+// LCOV_EXCL_START
 
 namespace rocalution
 {
@@ -1420,3 +1422,5 @@ namespace rocalution
             const;
 
 } // namespace rocalution
+
+// LCOV_EXCL_STOP

--- a/src/base/vector.cpp
+++ b/src/base/vector.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,6 +52,7 @@ namespace rocalution
         return this->GetSize();
     }
 
+    // LCOV_EXCL_START
     template <typename ValueType>
     void Vector<ValueType>::CopyFrom(const LocalVector<ValueType>& src)
     {
@@ -401,6 +402,7 @@ namespace rocalution
         y.Info();
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template class Vector<double>;
     template class Vector<float>;

--- a/src/solvers/iter_ctrl.cpp
+++ b/src/solvers/iter_ctrl.cpp
@@ -328,8 +328,10 @@ namespace rocalution
 
         if(!file.is_open())
         {
+            // LCOV_EXCL_START
             LOG_INFO("Can not open file [write]:" << filename);
             FATAL_ERROR(__FILE__, __LINE__);
+            // LCOV_EXCL_STOP
         }
 
         file.setf(std::ios::scientific);

--- a/src/solvers/mixed_precision.cpp
+++ b/src/solvers/mixed_precision.cpp
@@ -438,6 +438,7 @@ namespace rocalution
         log_debug(this, "MixedPrecisionDC::SolveNonPrecond_()", " #*# end");
     }
 
+    // LCOV_EXCL_START
     template <class OperatorTypeH,
               class VectorTypeH,
               typename ValueTypeH,
@@ -461,6 +462,7 @@ namespace rocalution
             "the preconditioner to the internal solver?");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template class MixedPrecisionDC<LocalMatrix<double>,
                                     LocalVector<double>,

--- a/src/solvers/multigrid/base_amg.cpp
+++ b/src/solvers/multigrid/base_amg.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -204,8 +204,10 @@ namespace rocalution
 
             if(this->op_->GetM() <= static_cast<int64_t>(this->coarse_size_))
             {
+                // LCOV_EXCL_START
                 LOG_INFO("Problem size too small for AMG, use Krylov solver instead");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
 
             // Lists for the building procedure
@@ -237,8 +239,10 @@ namespace rocalution
             // The very first level is not allowed to fail
             if(success == false)
             {
+                // LCOV_EXCL_START
                 LOG_INFO("Could not build initial AMG level");
                 FATAL_ERROR(__FILE__, __LINE__);
+                // LCOV_EXCL_STOP
             }
 
             ++this->levels_;
@@ -409,6 +413,7 @@ namespace rocalution
     {
     }
 
+    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void BaseAMG<OperatorType, VectorType, ValueType>::SetRestrictOperator(OperatorType** op)
     {
@@ -434,6 +439,7 @@ namespace rocalution
             "external operators");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template class BaseAMG<LocalMatrix<double>, LocalVector<double>, double>;
     template class BaseAMG<LocalMatrix<float>, LocalVector<float>, float>;

--- a/src/solvers/multigrid/base_multigrid.cpp
+++ b/src/solvers/multigrid/base_multigrid.cpp
@@ -92,6 +92,7 @@ namespace rocalution
         this->levels_ = levels;
     }
 
+    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void BaseMultiGrid<OperatorType, VectorType, ValueType>::SetPreconditioner(
         Solver<OperatorType, VectorType, ValueType>& precond)
@@ -100,6 +101,7 @@ namespace rocalution
                  "levels? use SetSmootherLevel() instead of SetPreconditioner!");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void BaseMultiGrid<OperatorType, VectorType, ValueType>::SetSmoother(
@@ -835,12 +837,12 @@ namespace rocalution
             this->Kcycle_(*rc, xc);
             break;
 
+        // LCOV_EXCL_START
         // F-cycle
         case 3:
             this->Fcycle_(*rc, xc);
             break;
 
-        // LCOV_EXCL_START
         default:
             FATAL_ERROR(__FILE__, __LINE__);
             break;
@@ -930,6 +932,7 @@ namespace rocalution
         }
     }
 
+    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void BaseMultiGrid<OperatorType, VectorType, ValueType>::Fcycle_(const VectorType& rhs,
                                                                      VectorType*       x)
@@ -937,6 +940,7 @@ namespace rocalution
         LOG_INFO("BaseMultiGrid:Fcycle_() not implemented yet");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void BaseMultiGrid<OperatorType, VectorType, ValueType>::Kcycle_(const VectorType& rhs,
@@ -1013,6 +1017,7 @@ namespace rocalution
         }
     }
 
+    // LCOV_EXCL_START
     // do nothing
     template <class OperatorType, class VectorType, typename ValueType>
     void BaseMultiGrid<OperatorType, VectorType, ValueType>::SolveNonPrecond_(const VectorType& rhs,
@@ -1034,6 +1039,7 @@ namespace rocalution
             "you are calling it ...");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template class BaseMultiGrid<LocalMatrix<double>, LocalVector<double>, double>;
     template class BaseMultiGrid<LocalMatrix<float>, LocalVector<float>, float>;

--- a/src/solvers/preconditioners/preconditioner.cpp
+++ b/src/solvers/preconditioners/preconditioner.cpp
@@ -87,13 +87,11 @@ namespace rocalution
         this->Clear();
     }
 
-    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void Jacobi<OperatorType, VectorType, ValueType>::Print(void) const
     {
         LOG_INFO("Jacobi preconditioner");
     }
-    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void Jacobi<OperatorType, VectorType, ValueType>::Build(void)
@@ -199,14 +197,12 @@ namespace rocalution
         this->Clear();
     }
 
-    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void GS<OperatorType, VectorType, ValueType>::Print(void) const
     {
         LOG_INFO("Gauss-Seidel (GS) preconditioner");
         this->solver_descr_.Print();
     }
-    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void GS<OperatorType, VectorType, ValueType>::Build(void)
@@ -297,14 +293,12 @@ namespace rocalution
         this->Clear();
     }
 
-    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void SGS<OperatorType, VectorType, ValueType>::Print(void) const
     {
         LOG_INFO("Symmetric Gauss-Seidel (SGS) preconditioner");
         this->solver_descr_.Print();
     }
-    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void SGS<OperatorType, VectorType, ValueType>::Build(void)
@@ -429,7 +423,6 @@ namespace rocalution
         this->Clear();
     }
 
-    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void ILU<OperatorType, VectorType, ValueType>::Print(void) const
     {
@@ -441,7 +434,6 @@ namespace rocalution
             this->solver_descr_.Print();
         }
     }
-    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void ILU<OperatorType, VectorType, ValueType>::Set(int p, bool level)
@@ -544,7 +536,6 @@ namespace rocalution
         this->Clear();
     }
 
-    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void ItILU0<OperatorType, VectorType, ValueType>::Print(void) const
     {
@@ -607,7 +598,6 @@ namespace rocalution
             this->solver_descr_.Print();
         }
     }
-    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void ItILU0<OperatorType, VectorType, ValueType>::SetAlgorithm(ItILU0Algorithm alg)
@@ -747,7 +737,6 @@ namespace rocalution
         this->Clear();
     }
 
-    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void ILUT<OperatorType, VectorType, ValueType>::Print(void) const
     {
@@ -759,7 +748,6 @@ namespace rocalution
             this->solver_descr_.Print();
         }
     }
-    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void ILUT<OperatorType, VectorType, ValueType>::Set(double t)
@@ -860,7 +848,6 @@ namespace rocalution
         this->Clear();
     }
 
-    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void IC<OperatorType, VectorType, ValueType>::Print(void) const
     {
@@ -872,7 +859,6 @@ namespace rocalution
             this->solver_descr_.Print();
         }
     }
-    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void IC<OperatorType, VectorType, ValueType>::Build(void)
@@ -961,7 +947,6 @@ namespace rocalution
         this->Clear();
     }
 
-    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void VariablePreconditioner<OperatorType, VectorType, ValueType>::Print(void) const
     {
@@ -978,7 +963,6 @@ namespace rocalution
             LOG_INFO("VariablePreconditioner preconditioner");
         }
     }
-    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void VariablePreconditioner<OperatorType, VectorType, ValueType>::SetPreconditioner(

--- a/src/solvers/preconditioners/preconditioner_as.cpp
+++ b/src/solvers/preconditioners/preconditioner_as.cpp
@@ -276,7 +276,7 @@ namespace rocalution
     template <class OperatorType, class VectorType, typename ValueType>
     void AS<OperatorType, VectorType, ValueType>::MoveToHostLocalData_(void)
     {
-        log_debug(this, "AS::MoveToAcceleratorLocalData_()", this->build_);
+        log_debug(this, "AS::MoveToHostLocalData_()", this->build_);
 
         if(this->build_ == true)
         {
@@ -295,7 +295,7 @@ namespace rocalution
     template <class OperatorType, class VectorType, typename ValueType>
     void AS<OperatorType, VectorType, ValueType>::MoveToAcceleratorLocalData_(void)
     {
-        log_debug(this, "AS::MoveToHostLocalData_()", this->build_);
+        log_debug(this, "AS::MoveToAcceleratorLocalData_()", this->build_);
 
         if(this->build_ == true)
         {

--- a/src/solvers/preconditioners/preconditioner_multielimination.hpp
+++ b/src/solvers/preconditioners/preconditioner_multielimination.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -67,17 +67,25 @@ namespace rocalution
         ROCALUTION_EXPORT
         virtual ~MultiElimination();
 
+        // LCOV_EXCL_START
         /** \brief Returns the size of the first (diagonal) block of the preconditioner */
         inline int GetSizeDiagBlock(void) const
         {
+            // LCOV_EXCL_STOP
             return this->size_;
+            // LCOV_EXCL_START
         }
+        // LCOV_EXCL_STOP
 
+        // LCOV_EXCL_START
         /** \brief Return the depth of the current level */
         inline int GetLevel(void) const
         {
+            // LCOV_EXCL_STOP
             return this->level_;
+            // LCOV_EXCL_START
         }
+        // LCOV_EXCL_STOP
 
         ROCALUTION_EXPORT
         virtual void Print(void) const;

--- a/src/solvers/preconditioners/preconditioner_saddlepoint.cpp
+++ b/src/solvers/preconditioners/preconditioner_saddlepoint.cpp
@@ -266,6 +266,7 @@ namespace rocalution
         log_debug(this, "DiagJacobiSaddlePointPrecond::Solve()", " #*# end");
     }
 
+    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void DiagJacobiSaddlePointPrecond<OperatorType, VectorType, ValueType>::MoveToHostLocalData_(
         void)
@@ -328,6 +329,7 @@ namespace rocalution
             this->S_solver_->MoveToAccelerator();
         }
     }
+    // LCOV_EXCL_STOP
 
     template class DiagJacobiSaddlePointPrecond<LocalMatrix<double>, LocalVector<double>, double>;
     template class DiagJacobiSaddlePointPrecond<LocalMatrix<float>, LocalVector<float>, float>;

--- a/src/solvers/solver.cpp
+++ b/src/solvers/solver.cpp
@@ -671,6 +671,7 @@ namespace rocalution
         }
     }
 
+    // LCOV_EXCL_START
     template <class OperatorType, class VectorType, typename ValueType>
     void FixedPoint<OperatorType, VectorType, ValueType>::SolveNonPrecond_(const VectorType& rhs,
                                                                            VectorType*       x)
@@ -678,6 +679,7 @@ namespace rocalution
         LOG_INFO("Preconditioner for the Fixed Point method is required");
         FATAL_ERROR(__FILE__, __LINE__);
     }
+    // LCOV_EXCL_STOP
 
     template <class OperatorType, class VectorType, typename ValueType>
     void FixedPoint<OperatorType, VectorType, ValueType>::SolvePrecond_(const VectorType& rhs,

--- a/src/solvers/solver.hpp
+++ b/src/solvers/solver.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -245,17 +245,25 @@ namespace rocalution
         ROCALUTION_EXPORT
         virtual void SetSolverDescriptor(const SolverDescr& descr);
 
+        // LCOV_EXCL_START
         /** \brief Mark this solver as being a preconditioner */
         inline void FlagPrecond(void)
         {
+            // LCOV_EXCL_STOP
             this->is_precond_ = true;
+            // LCOV_EXCL_START
         }
+        // LCOV_EXCL_STOP
 
+        // LCOV_EXCL_START
         /** \brief Mark this solver as being a smoother */
         inline void FlagSmoother(void)
         {
+            // LCOV_EXCL_STOP
             this->is_smoother_ = true;
+            // LCOV_EXCL_START
         }
+        // LCOV_EXCL_STOP
 
     protected:
         /** \brief Pointer to the operator */

--- a/src/utils/log.cpp
+++ b/src/utils/log.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2020 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ namespace rocalution
         char* str_layer_mode;
         if((str_layer_mode = getenv("ROCALUTION_LAYER")) != NULL)
         {
+            // LCOV_EXCL_START
             if(atoi(str_layer_mode) == 1)
             {
                 if(_get_backend_descriptor()->log_file != NULL)
@@ -66,6 +67,7 @@ namespace rocalution
                 _get_backend_descriptor()->log_file->open(str_name.c_str(),
                                                           std::ios::out | std::ios::trunc);
             }
+            // LCOV_EXCL_STOP
         }
     }
 
@@ -73,12 +75,14 @@ namespace rocalution
     {
         if(_get_backend_descriptor()->log_file != NULL)
         {
+            // LCOV_EXCL_START
             if(_get_backend_descriptor()->log_file->is_open())
             {
                 _get_backend_descriptor()->log_file->close();
                 delete _get_backend_descriptor()->log_file;
                 _get_backend_descriptor()->log_file = NULL;
             }
+            // LCOV_EXCL_STOP
         }
     }
 

--- a/src/utils/log.hpp
+++ b/src/utils/log.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2020 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -78,9 +78,11 @@ namespace rocalution
     {
         if(_get_backend_descriptor()->log_file != NULL)
         {
+            // LCOV_EXCL_START
             std::string   comma_separator = ", ";
             std::ostream* os              = _get_backend_descriptor()->log_file;
             log_arguments(*os, comma_separator, _get_backend_descriptor()->rank, ptr, fct, xs...);
+            // LCOV_EXCL_STOP
         }
     }
 


### PR DESCRIPTION
This PR excludes from the code coverage report some parts of the source code that:
- deal with `FATAL_ERROR`,
- define inline function,
- return errros.