### PR TITLE
add tests for Chebyshev, itsolver, mixed precision, and the preconditioners

### DIFF
--- a/clients/include/testing_chebyshev.hpp
+++ b/clients/include/testing_chebyshev.hpp
@@ -1,0 +1,218 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#pragma once
+
+#include "utility.hpp"
+
+#include <rocalution/rocalution.hpp>
+
+template <typename T>
+bool testing_chebyshev(Arguments argus)
+{
+    using namespace rocalution;
+
+    int          ndim                = argus.size;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    std::string  matrix_type         = argus.matrix_type;
+    bool         rebuildnumeric      = argus.rebuildnumeric;
+    bool         disable_accelerator = !argus.use_acc;
+
+    // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
+    set_device_rocalution(device);
+    init_rocalution();
+
+    // rocALUTION structures
+    LocalMatrix<T>  A;
+    LocalVector<T>  x;
+    LocalVector<T>  b;
+    LocalVector<T>  b_old;
+    LocalVector<T>* b_k;
+    LocalVector<T>* b_k1;
+    LocalVector<T>* b_tmp;
+    LocalVector<T>  e;
+    LocalVector<T>  rhs;
+
+    // Generate A
+    int* csr_ptr = NULL;
+    int* csr_col = NULL;
+    T*   csr_val = NULL;
+
+    int nrow = 0;
+    int ncol = 0;
+    if(matrix_type == "Laplacian2D")
+    {
+        nrow = gen_2d_laplacian(ndim, &csr_ptr, &csr_col, &csr_val);
+        ncol = nrow;
+    }
+    else
+    {
+        stop_rocalution();
+        disable_accelerator_rocalution(false);
+        return true;
+    }
+    int nnz = csr_ptr[nrow];
+
+    T* csr_val2 = NULL;
+    if(rebuildnumeric)
+    {
+        csr_val2 = new T[nnz];
+        for(int i = 0; i < nnz; i++)
+        {
+            csr_val2[i] = csr_val[i];
+        }
+    }
+
+    A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
+
+    // Move data to accelerator
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        rhs.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
+
+    // Allocate x, b and e
+    x.Allocate("x", A.GetN());
+    rhs.Allocate("b", A.GetM());
+    e.Allocate("e", A.GetN());
+
+    T lambda_min;
+    T lambda_max;
+
+    A.Gershgorin(lambda_min, lambda_max);
+
+    // Chebyshev iteration
+    Chebyshev<LocalMatrix<T>, LocalVector<T>, T> ls;
+
+    // Initialize rhs such that A 1 = rhs
+    e.Ones();
+    A.Apply(e, &rhs);
+
+    // Initial zero guess
+    x.Zeros();
+
+    // Preconditioner
+    Preconditioner<LocalMatrix<T>, LocalVector<T>, T>* p;
+
+    if(precond == "None")
+        p = NULL;
+    else if(precond == "Chebyshev")
+    {
+        // Chebyshev preconditioner
+
+        // Determine min and max eigenvalues
+        T lambda_min;
+        T lambda_max;
+
+        A.Gershgorin(lambda_min, lambda_max);
+
+        AIChebyshev<LocalMatrix<T>, LocalVector<T>, T>* cheb
+            = new AIChebyshev<LocalMatrix<T>, LocalVector<T>, T>;
+        cheb->Set(3, lambda_max / 7.0, lambda_max);
+
+        p = cheb;
+    }
+    else if(precond == "FSAI")
+        p = new FSAI<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "SPAI")
+        p = new SPAI<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "TNS")
+        p = new TNS<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "Jacobi")
+        p = new Jacobi<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "GS")
+        p = new GS<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "SGS")
+        p = new SGS<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "ILU")
+        p = new ILU<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "ItILU0")
+        p = new ItILU0<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "ILUT")
+        p = new ILUT<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "IC")
+        p = new IC<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "MCGS")
+        p = new MultiColoredGS<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "MCSGS")
+        p = new MultiColoredSGS<LocalMatrix<T>, LocalVector<T>, T>;
+    else if(precond == "MCILU")
+        p = new MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>;
+    else
+        return false;
+
+    // Set solver operator
+    ls.SetOperator(A);
+
+    ls.Verbose(0);
+    ls.SetOperator(A);
+
+    // Set preconditioner
+    if(p != NULL)
+    {
+        ls.SetPreconditioner(*p);
+    }
+
+    // Set eigenvalues
+    ls.Set(lambda_min, lambda_max);
+
+    // Build solver
+    ls.Build();
+
+    if(rebuildnumeric)
+    {
+        A.UpdateValuesCSR(csr_val2);
+        delete[] csr_val2;
+
+        A.Apply(e, &rhs);
+
+        ls.ReBuildNumeric();
+        ls.Set(lambda_min, lambda_max);
+    }
+
+    // Solve A x = rhs
+    ls.Solve(rhs, &x);
+
+    // Clear solver
+    ls.Clear();
+    if(p != NULL)
+    {
+        delete p;
+    }
+
+    // Compute error L2 norm
+    e.ScaleAdd(-1.0, x);
+    T error = e.Norm();
+    std::cout << "Chebyshev iteration ||e - x||_2 = " << error << std::endl;
+
+    // Stop rocALUTION platform
+    stop_rocalution();
+    disable_accelerator_rocalution(false);
+
+    return true;
+}

--- a/clients/include/testing_itsolver.hpp
+++ b/clients/include/testing_itsolver.hpp
@@ -1,0 +1,165 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#pragma once
+
+#include "utility.hpp"
+
+#include <rocalution/rocalution.hpp>
+
+template <typename T>
+bool testing_itsolver(Arguments argus)
+{
+    using namespace rocalution;
+
+    int          ndim                = argus.size;
+    unsigned int format              = argus.format;
+    std::string  matrix_type         = argus.matrix_type;
+    bool         disable_accelerator = !argus.use_acc;
+
+    // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
+    set_device_rocalution(device);
+    init_rocalution();
+
+    // rocALUTION structures
+    LocalMatrix<T> A;
+    LocalVector<T> x;
+    LocalVector<T> b;
+    LocalVector<T> e;
+
+    // Generate A
+    int* csr_ptr = NULL;
+    int* csr_col = NULL;
+    T*   csr_val = NULL;
+
+    int nrow = 0;
+    int ncol = 0;
+    if(matrix_type == "Laplacian2D")
+    {
+        nrow = gen_2d_laplacian(ndim, &csr_ptr, &csr_col, &csr_val);
+        ncol = nrow;
+    }
+    else if(matrix_type == "PermutedIdentity")
+    {
+        nrow = gen_permuted_identity(ndim, &csr_ptr, &csr_col, &csr_val);
+        ncol = nrow;
+    }
+    else
+    {
+        stop_rocalution();
+        disable_accelerator_rocalution(false);
+        return true;
+    }
+    int nnz = csr_ptr[nrow];
+
+    A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
+
+    // Move data to accelerator
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
+
+    // Allocate x, b and e
+    x.Allocate("x", A.GetN());
+    b.Allocate("b", A.GetM());
+    e.Allocate("e", A.GetN());
+
+    // Linear Solver
+    FixedPoint<LocalMatrix<T>, LocalVector<T>, T> fp;
+
+    // Preconditioner
+    ItILU0<LocalMatrix<T>, LocalVector<T>, T> p;
+
+    // Set iterative ILU stopping criteria
+    p.SetTolerance(1e-8);
+    p.SetMaxIter(50);
+
+    p.SetAlgorithm(ItILU0Algorithm::SyncSplit);
+
+    // Set up iterative triangular solve
+    SolverDescr descr;
+    descr.SetTriSolverAlg(TriSolverAlg_Iterative);
+    descr.SetIterativeSolverMaxIteration(30);
+    descr.SetIterativeSolverTolerance(1e-8);
+
+    descr.DisableIterativeSolverTolerance();
+    descr.EnableIterativeSolverTolerance();
+    SolverDescr descr_new(descr); // Copy the descriptor
+
+    p.SetSolverDescriptor(descr_new);
+
+    // Initialize b such that A 1 = b
+    e.Ones();
+    A.Apply(e, &b);
+
+    // Initial zero guess
+    x.Zeros();
+
+    // Set solver operator
+    fp.SetOperator(A);
+    // Set solver preconditioner
+    fp.SetPreconditioner(p);
+
+    // Build solver
+    fp.Build();
+
+    // Verbosity output
+    fp.Verbose(1);
+
+    fp.InitMinIter(1);
+    fp.InitMaxIter(1000);
+    fp.InitTol(1e-8, 1e-8, 1e-8);
+
+    // Print matrix info
+    A.Info();
+
+    // Solve A x = b
+    fp.Solve(b, &x);
+
+    int           niter_preconditioner;
+    const double* history = p.GetConvergenceHistory(&niter_preconditioner);
+
+    auto res_final = fp.GetCurrentResidual();
+    //auto res_init      = fp.GetInitialResidual();
+    //auto niter         = fp.GetNumIterations();
+    auto status_solver = fp.GetSolverStatus();
+    auto ind           = fp.GetAmaxResidualIndex();
+    // Clear solver
+    fp.Clear();
+
+    // Compute error L2 norm
+    e.ScaleAdd(-1.0, x);
+    T error = e.Norm();
+    std::cout << "||e - x||_2 = " << error << std::endl;
+
+    // Stop rocALUTION platform
+    stop_rocalution();
+    disable_accelerator_rocalution(false);
+
+    return true;
+}

--- a/clients/include/testing_mixed_precision.hpp
+++ b/clients/include/testing_mixed_precision.hpp
@@ -1,0 +1,135 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#pragma once
+
+#include "utility.hpp"
+
+#include <rocalution/rocalution.hpp>
+
+template <typename T>
+bool testing_mixed_precision(Arguments argus)
+{
+    using namespace rocalution;
+
+    int          ndim           = argus.size;
+    std::string  precond        = argus.precond;
+    unsigned int format         = argus.format;
+    std::string  matrix_type    = argus.matrix_type;
+    bool         rebuildnumeric = argus.rebuildnumeric;
+
+    // Initialize rocALUTION platform
+    set_device_rocalution(device);
+    init_rocalution();
+
+    // rocALUTION structures
+    LocalMatrix<T> A;
+    LocalVector<T> x;
+    LocalVector<T> e;
+    LocalVector<T> rhs;
+
+    // Generate A
+    int* csr_ptr = NULL;
+    int* csr_col = NULL;
+    T*   csr_val = NULL;
+
+    int nrow = 0;
+    int ncol = 0;
+    if(matrix_type == "Laplacian2D")
+    {
+        nrow = gen_2d_laplacian(ndim, &csr_ptr, &csr_col, &csr_val);
+        ncol = nrow;
+    }
+    else
+    {
+        stop_rocalution();
+        disable_accelerator_rocalution(false);
+        return true;
+    }
+    int nnz = csr_ptr[nrow];
+
+    T* csr_val2 = NULL;
+    if(rebuildnumeric)
+    {
+        csr_val2 = new T[nnz];
+        for(int i = 0; i < nnz; i++)
+        {
+            csr_val2[i] = csr_val[i];
+        }
+    }
+
+    A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
+
+    // Allocate x, b and e
+    x.Allocate("x", A.GetN());
+    rhs.Allocate("b", A.GetM());
+    e.Allocate("e", A.GetN());
+
+    // Linear Solver
+    MixedPrecisionDC<LocalMatrix<T>,
+                     LocalVector<T>,
+                     T,
+                     LocalMatrix<float>,
+                     LocalVector<float>,
+                     float>
+                                                                   mp;
+    CG<LocalMatrix<float>, LocalVector<float>, float>              cg;
+    MultiColoredILU<LocalMatrix<float>, LocalVector<float>, float> p;
+
+    // Initialize rhs such that A 1 = rhs
+    e.Ones();
+    A.Apply(e, &rhs);
+
+    // Initial zero guess
+    x.Zeros();
+
+    // setup a lower tol for the inner solver
+    cg.SetPreconditioner(p);
+    cg.Init(1e-5, 1e-2, 1e+20, 100000);
+
+    // setup the mixed-precision DC
+    mp.SetOperator(A);
+    mp.Set(cg);
+
+    // Build solver
+    mp.Build();
+
+    // Verbosity output
+    mp.Verbose(1);
+
+    // Solve A x = rhs
+    mp.Solve(rhs, &x);
+
+    // Compute error L2 norm
+    e.ScaleAdd(-1.0, x);
+    T error = e.Norm();
+    std::cout << "||e - x||_2 = " << error << std::endl;
+
+    // Clear solver
+    mp.Clear();
+
+    // Stop rocALUTION platform
+    stop_rocalution();
+
+    return true;
+}

--- a/clients/include/testing_preconditioner.hpp
+++ b/clients/include/testing_preconditioner.hpp
@@ -28,8 +28,6 @@
 #include <gtest/gtest.h>
 #include <rocalution/rocalution.hpp>
 
-//#include "testing_local_matrix.hpp"
-
 using namespace rocalution;
 
 template <typename T>

--- a/clients/include/testing_preconditioner.hpp
+++ b/clients/include/testing_preconditioner.hpp
@@ -1,0 +1,382 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#pragma once
+
+#include "utility.hpp"
+
+#include <gtest/gtest.h>
+#include <rocalution/rocalution.hpp>
+
+//#include "testing_local_matrix.hpp"
+
+using namespace rocalution;
+
+template <typename T>
+void getTestMatrix(Arguments argus, LocalMatrix<T>& matrix)
+{
+    int         size        = argus.size;
+    std::string matrix_type = argus.matrix_type;
+
+    // Generate A
+    int* csr_ptr = NULL;
+    int* csr_col = NULL;
+    T*   csr_val = NULL;
+
+    int nrow = gen_2d_laplacian(size, &csr_ptr, &csr_col, &csr_val);
+    int ncol = nrow;
+
+    int nnz = csr_ptr[nrow];
+
+    matrix.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "TestMatrix", nnz, nrow, ncol);
+}
+
+template <typename T>
+void testing_preconditioner_all(Arguments argus)
+{
+    std::string precond = argus.precond;
+
+    LocalMatrix<T> matrix;
+    getTestMatrix<T>(argus, matrix);
+    GMRES<LocalMatrix<T>, LocalVector<T>, T> ls;
+
+    std::cout << "Testing preconditioner: " << precond << std::endl;
+    std::cout << "Matrix size: " << matrix.GetM() << " x " << matrix.GetN() << std::endl;
+
+    Preconditioner<LocalMatrix<T>, LocalVector<T>, T>*  p;
+    MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>* mcilu_p = NULL;
+    Solver<LocalMatrix<T>, LocalVector<T>, T>**         vp      = NULL;
+
+    ls.Verbose(0);
+    ls.SetOperator(matrix);
+
+    if(precond == "Jacobi")
+    {
+        p = new Jacobi<LocalMatrix<T>, LocalVector<T>, T>;
+    }
+    else if(precond == "GS")
+    {
+        p = new GS<LocalMatrix<T>, LocalVector<T>, T>;
+    }
+    else if(precond == "SGS")
+    {
+        p = new SGS<LocalMatrix<T>, LocalVector<T>, T>;
+    }
+    else if(precond == "ILU")
+    {
+        p = new ILU<LocalMatrix<T>, LocalVector<T>, T>;
+        static_cast<ILU<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(0, true);
+    }
+    else if(precond == "ItILU0")
+    {
+        p = new ItILU0<LocalMatrix<T>, LocalVector<T>, T>;
+        static_cast<ItILU0<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetAlgorithm(
+            ItILU0Algorithm::Default);
+        static_cast<ItILU0<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetOptions(
+            ItILU0Option::Verbose);
+        static_cast<ItILU0<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetMaxIter(10);
+        static_cast<ItILU0<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetTolerance(1e-6);
+    }
+    else if(precond == "ILUT")
+    {
+        p = new ILUT<LocalMatrix<T>, LocalVector<T>, T>;
+        static_cast<ILUT<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(1.);
+        static_cast<ILUT<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(1., 10);
+    }
+    else if(precond == "IC")
+    {
+        p = new IC<LocalMatrix<T>, LocalVector<T>, T>;
+    }
+    else if(precond == "AIChebyshev")
+    {
+        p = new AIChebyshev<LocalMatrix<T>, LocalVector<T>, T>;
+        T lambda_min;
+        T lambda_max;
+
+        matrix.Gershgorin(lambda_min, lambda_max);
+
+        static_cast<AIChebyshev<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(
+            3, lambda_max / 7.0, lambda_max);
+    }
+    else if(precond == "FSAI")
+    {
+        p = new FSAI<LocalMatrix<T>, LocalVector<T>, T>;
+        static_cast<FSAI<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(2);
+        static_cast<FSAI<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(matrix);
+        static_cast<FSAI<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetPrecondMatrixFormat(CSR);
+    }
+    else if(precond == "SPAI")
+    {
+        p = new SPAI<LocalMatrix<T>, LocalVector<T>, T>;
+        static_cast<SPAI<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetPrecondMatrixFormat(CSR);
+    }
+    else if(precond == "TNS")
+    {
+        p = new TNS<LocalMatrix<T>, LocalVector<T>, T>;
+        static_cast<TNS<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(true);
+        static_cast<TNS<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetPrecondMatrixFormat(CSR);
+    }
+    else if(precond == "AS")
+    {
+        p = new AS<LocalMatrix<T>, LocalVector<T>, T>;
+
+        // Second level preconditioners
+        Solver<LocalMatrix<T>, LocalVector<T>, T>** p2;
+
+        int n = 2;
+        p2    = new Solver<LocalMatrix<T>, LocalVector<T>, T>*[n];
+
+        for(int i = 0; i < n; ++i)
+        {
+            MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>* mc;
+            mc    = new MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>;
+            p2[i] = mc;
+        }
+
+        // Initialize preconditioner
+        static_cast<AS<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(n, 4, p2);
+    }
+    else if(precond == "RAS")
+    {
+        p = new RAS<LocalMatrix<T>, LocalVector<T>, T>;
+
+        // Second level preconditioners
+        Solver<LocalMatrix<T>, LocalVector<T>, T>** p2;
+
+        int n = 2;
+        p2    = new Solver<LocalMatrix<T>, LocalVector<T>, T>*[n];
+
+        for(int i = 0; i < n; ++i)
+        {
+            MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>* mc;
+            mc    = new MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>;
+            p2[i] = mc;
+        }
+
+        // Initialize preconditioner
+        static_cast<RAS<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(n, 4, p2);
+    }
+    else if(precond == "MultiColoredSGS")
+    {
+        p = new MultiColoredSGS<LocalMatrix<T>, LocalVector<T>, T>;
+        static_cast<MultiColoredSGS<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetRelaxation(0.9);
+        static_cast<MultiColoredSGS<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetPrecondMatrixFormat(
+            CSR);
+    }
+    else if(precond == "MultiColoredGS")
+    {
+        p = new MultiColoredGS<LocalMatrix<T>, LocalVector<T>, T>;
+        static_cast<MultiColoredGS<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetRelaxation(0.9);
+        static_cast<MultiColoredGS<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetPrecondMatrixFormat(
+            CSR);
+    }
+    else if(precond == "MultiColoredILU")
+    {
+        p = new MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>;
+        static_cast<MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(0);
+        static_cast<MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(0, 1, true);
+        static_cast<MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>*>(p)->SetPrecondMatrixFormat(
+            CSR);
+    }
+    else if(precond == "MultiElimination")
+    {
+        p = new MultiElimination<LocalMatrix<T>, LocalVector<T>, T>;
+
+        mcilu_p = new MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>;
+        mcilu_p->Set(0);
+        static_cast<MultiElimination<LocalMatrix<T>, LocalVector<T>, T>*>(p)->Set(*mcilu_p, 2, 0.4);
+    }
+    else if(precond == "VariablePreconditioner")
+    {
+        p = new VariablePreconditioner<LocalMatrix<T>, LocalVector<T>, T>;
+
+        vp = new Solver<LocalMatrix<T>, LocalVector<T>, T>*[3];
+
+        // Preconditioners
+        vp[0] = new MultiColoredSGS<LocalMatrix<T>, LocalVector<T>, T>;
+        vp[1] = new MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>;
+        vp[2] = new ILU<LocalMatrix<T>, LocalVector<T>, T>;
+
+        // Set variable preconditioners
+        static_cast<VariablePreconditioner<LocalMatrix<T>, LocalVector<T>, T>*>(p)
+            ->SetPreconditioner(3, vp);
+    }
+    else
+    {
+        std::cerr << "Unknown preconditioner: " << precond << std::endl;
+        exit(1);
+    }
+
+    ls.SetPreconditioner(*p);
+
+    ls.Init(1e-6, 0.0, 1e+8, 10000);
+
+    ls.Build();
+
+    if(precond == "Jacobi")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "GS")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "SGS")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "ILU")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "ItILU0")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "ILUT")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "IC")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "AIChebyshev")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "FSAI")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "SPAI")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "TNS")
+    {
+        p->Build(); // trigger a clear of the preconditioner followed by a build
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "AS")
+    {
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "RAS")
+    {
+        p->ResetOperator(matrix);
+    }
+    else if(precond == "MultiColoredSGS")
+    {
+        p->ResetOperator(matrix);
+        p->ReBuildNumeric();
+    }
+    else if(precond == "MultiColoredGS")
+    {
+        p->ResetOperator(matrix);
+        p->ReBuildNumeric();
+    }
+    else if(precond == "MultiColoredILU")
+    {
+        p->ResetOperator(matrix);
+        p->ReBuildNumeric();
+    }
+    else if(precond == "MultiElimination")
+    {
+        p->ResetOperator(matrix);
+    }
+
+    p->Print();
+
+    // Test the preconditioner
+    LocalVector<T> x_acc, x_host, b, e;
+
+    x_acc.Allocate("x", matrix.GetM());
+    x_host.Allocate("x", matrix.GetM());
+    b.Allocate("b", matrix.GetM());
+    e.Allocate("e", matrix.GetM());
+
+    ls.MoveToAccelerator();
+    p->MoveToAccelerator();
+    matrix.MoveToAccelerator();
+    x_acc.MoveToAccelerator();
+    b.MoveToAccelerator();
+    e.MoveToAccelerator();
+
+    if(precond != "ILUT" && precond != "IC")
+    {
+        e.Ones();
+        matrix.Apply(e, &b);
+        p->Solve(b, &x_acc);
+
+        // Compute error L2 norm
+        e.ScaleAdd(-1.0, x_acc);
+        T error_acc = e.Norm();
+        std::cout << "error_acc =" << error_acc << std::endl;
+    }
+
+    ls.MoveToHost();
+    p->MoveToHost();
+    matrix.MoveToHost();
+    x_acc.MoveToHost();
+    e.MoveToHost();
+    b.MoveToHost();
+
+    e.Ones();
+    matrix.Apply(e, &b);
+    p->Solve(b, &x_host);
+
+    // Compute error L2 norm
+    e.ScaleAdd(-1.0, x_host);
+    T error_host = e.Norm();
+    std::cout << "error_host = " << error_host << std::endl;
+
+    if(precond != "ILUT" && precond != "IC")
+    {
+        x_host.ScaleAdd(-1.0, x_acc);
+        T diff = x_host.Norm();
+        std::cout << "diff = " << diff << std::endl;
+    }
+
+    ls.Clear();
+    delete p;
+    if(mcilu_p != NULL)
+    {
+        delete mcilu_p;
+    }
+
+    if(vp != NULL)
+    {
+        delete[] vp;
+    }
+}

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -49,7 +49,7 @@ set(ROCALUTION_TEST_SOURCES
   test_ruge_stueben_amg.cpp
   test_saamg.cpp
   test_uaamg.cpp
-# Other iterative solvers
+# Other tests
   test_preconditioner.cpp
   test_itersolver.cpp
   test_chebyshev.cpp

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,11 @@ set(ROCALUTION_TEST_SOURCES
   test_ruge_stueben_amg.cpp
   test_saamg.cpp
   test_uaamg.cpp
+# Other iterative solvers
+  test_preconditioner.cpp
+  test_itersolver.cpp
+  test_chebyshev.cpp
+  test_mixed_precision.cpp
 )
 
 if(NOT WIN32)

--- a/clients/tests/test_chebyshev.cpp
+++ b/clients/tests/test_chebyshev.cpp
@@ -1,0 +1,99 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include "testing_chebyshev.hpp"
+#include "utility.hpp"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+typedef std::tuple<int, unsigned int, std::string, std::string, int, int> chebyshev_tuple;
+
+std::vector<int>          chebyshev_size           = {7};
+std::vector<unsigned int> chebyshev_format         = {1, 2, 3, 4, 5, 6, 7};
+std::vector<std::string>  chebyshev_matrix_type    = {"Laplacian2D"};
+std::vector<std::string>  chebyshev_precond        = {"None", "FSAI"};
+std::vector<int>          chebyshev_rebuildnumeric = {0};
+std::vector<int>          chebyshev_use_acc        = {0, 1};
+
+// Function to update tests if environment variable is set
+void update_chebyshev() {}
+
+struct ChebyshevInitializer
+{
+    ChebyshevInitializer()
+    {
+        update_chebyshev();
+    }
+};
+
+// Create a global instance of the initializer, so the environment is checked and updated before tests.
+ChebyshevInitializer chebyshev_initializer;
+
+class parameterized_chebyshev : public testing::TestWithParam<chebyshev_tuple>
+{
+protected:
+    parameterized_chebyshev() {}
+    virtual ~parameterized_chebyshev() {}
+    virtual void SetUp()
+    {
+        if(!is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+        {
+            GTEST_SKIP() << "Skipping Chebyshev tests as ROCLUTION_CODE_COVERAGE is not set.";
+        }
+    }
+    virtual void TearDown() {}
+};
+
+Arguments setup_chebyshev_arguments(chebyshev_tuple tup)
+{
+    Arguments arg;
+    arg.size           = std::get<0>(tup);
+    arg.format         = std::get<1>(tup);
+    arg.matrix_type    = std::get<2>(tup);
+    arg.precond        = std::get<3>(tup);
+    arg.rebuildnumeric = std::get<4>(tup);
+    arg.use_acc        = std::get<5>(tup);
+    return arg;
+}
+
+TEST_P(parameterized_chebyshev, chebyshev_float)
+{
+    Arguments arg = setup_chebyshev_arguments(GetParam());
+    ASSERT_EQ(testing_chebyshev<float>(arg), true);
+}
+
+TEST_P(parameterized_chebyshev, chebyshev_double)
+{
+    Arguments arg = setup_chebyshev_arguments(GetParam());
+    ASSERT_EQ(testing_chebyshev<double>(arg), true);
+}
+
+INSTANTIATE_TEST_CASE_P(chebyshev,
+                        parameterized_chebyshev,
+                        testing::Combine(testing::ValuesIn(chebyshev_size),
+                                         testing::ValuesIn(chebyshev_format),
+                                         testing::ValuesIn(chebyshev_matrix_type),
+                                         testing::ValuesIn(chebyshev_precond),
+                                         testing::ValuesIn(chebyshev_rebuildnumeric),
+                                         testing::ValuesIn(chebyshev_use_acc)));

--- a/clients/tests/test_itersolver.cpp
+++ b/clients/tests/test_itersolver.cpp
@@ -1,0 +1,93 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include "testing_itsolver.hpp"
+#include "utility.hpp"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+typedef std::tuple<int, unsigned int, std::string, int> itsolver_tuple;
+
+std::vector<int>          itsolver_size        = {7};
+std::vector<unsigned int> itsolver_format      = {1, 2, 3, 4, 5, 6, 7};
+std::vector<std::string>  itsolver_matrix_type = {"Laplacian2D"};
+std::vector<int>          itsolver_use_acc     = {0, 1};
+
+// Function to update tests if environment variable is set
+void update_itsolver() {}
+
+struct ItsolverInitializer
+{
+    ItsolverInitializer()
+    {
+        update_itsolver();
+    }
+};
+
+// Create a global instance of the initializer, so the environment is checked and updated before tests.
+ItsolverInitializer itsolver_initializer;
+
+class parameterized_itsolver : public testing::TestWithParam<itsolver_tuple>
+{
+protected:
+    parameterized_itsolver() {}
+    virtual ~parameterized_itsolver() {}
+    virtual void SetUp()
+    {
+        if(!is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+        {
+            GTEST_SKIP() << "Skipping tests as ROCALUTION_CODE_COVERAGE is not set.";
+        }
+    }
+    virtual void TearDown() {}
+};
+
+Arguments setup_itsolver_arguments(itsolver_tuple tup)
+{
+    Arguments arg;
+    arg.size        = std::get<0>(tup);
+    arg.format      = std::get<1>(tup);
+    arg.matrix_type = std::get<2>(tup);
+    arg.use_acc     = std::get<3>(tup);
+    return arg;
+}
+
+TEST_P(parameterized_itsolver, itsolver_float)
+{
+    Arguments arg = setup_itsolver_arguments(GetParam());
+    ASSERT_EQ(testing_itsolver<float>(arg), true);
+}
+
+TEST_P(parameterized_itsolver, itsolver_double)
+{
+    Arguments arg = setup_itsolver_arguments(GetParam());
+    ASSERT_EQ(testing_itsolver<double>(arg), true);
+}
+
+INSTANTIATE_TEST_CASE_P(itsolver,
+                        parameterized_itsolver,
+                        testing::Combine(testing::ValuesIn(itsolver_size),
+                                         testing::ValuesIn(itsolver_format),
+                                         testing::ValuesIn(itsolver_matrix_type),
+                                         testing::ValuesIn(itsolver_use_acc)));

--- a/clients/tests/test_mixed_precision.cpp
+++ b/clients/tests/test_mixed_precision.cpp
@@ -1,0 +1,91 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include "testing_mixed_precision.hpp"
+#include "utility.hpp"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+typedef std::tuple<int, unsigned int, std::string, std::string, int> mixed_precision_tuple;
+
+std::vector<int>          mixed_precision_size           = {7};
+std::vector<unsigned int> mixed_precision_format         = {1, 2, 3, 4, 5, 6, 7};
+std::vector<std::string>  mixed_precision_matrix_type    = {"Laplacian2D"};
+std::vector<std::string>  mixed_precision_precond        = {"None", "FSAI"};
+std::vector<int>          mixed_precision_rebuildnumeric = {0};
+
+// Function to update tests if environment variable is set
+void update_mixed_precision() {}
+
+struct MPInitializer
+{
+    MPInitializer()
+    {
+        update_mixed_precision();
+    }
+};
+
+// Create a global instance of the initializer, so the environment is checked and updated before tests.
+MPInitializer mixed_precision_initializer;
+
+class parameterized_mixed_precision : public testing::TestWithParam<mixed_precision_tuple>
+{
+protected:
+    parameterized_mixed_precision() {}
+    virtual ~parameterized_mixed_precision() {}
+    virtual void SetUp()
+    {
+        if(!is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+        {
+            GTEST_SKIP()
+                << "Skipping mixed precision tests as ROCALUTION_CODE_COVERAGE is not set.";
+        }
+    }
+    virtual void TearDown() {}
+};
+
+Arguments setup_mixed_precision_arguments(mixed_precision_tuple tup)
+{
+    Arguments arg;
+    arg.size           = std::get<0>(tup);
+    arg.format         = std::get<1>(tup);
+    arg.matrix_type    = std::get<2>(tup);
+    arg.precond        = std::get<3>(tup);
+    arg.rebuildnumeric = std::get<4>(tup);
+    return arg;
+}
+
+TEST_P(parameterized_mixed_precision, mixed_precision_double_float)
+{
+    Arguments arg = setup_mixed_precision_arguments(GetParam());
+    ASSERT_EQ(testing_mixed_precision<double>(arg), true);
+}
+
+INSTANTIATE_TEST_CASE_P(mixed_precision,
+                        parameterized_mixed_precision,
+                        testing::Combine(testing::ValuesIn(mixed_precision_size),
+                                         testing::ValuesIn(mixed_precision_format),
+                                         testing::ValuesIn(mixed_precision_matrix_type),
+                                         testing::ValuesIn(mixed_precision_precond),
+                                         testing::ValuesIn(mixed_precision_rebuildnumeric)));

--- a/clients/tests/test_preconditioner.cpp
+++ b/clients/tests/test_preconditioner.cpp
@@ -1,0 +1,114 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include "testing_preconditioner.hpp"
+#include "utility.hpp"
+
+#include <gtest/gtest.h>
+
+typedef std::tuple<int, std::string> preconditioner_tuple;
+
+int         preconditioner_size[] = {7};
+std::string preconditioner_type[] = {"Jacobi",
+                                     "GS",
+                                     "SGS",
+                                     "ILU",
+                                     "ILUT",
+                                     "IC",
+                                     "ItILU0",
+                                     "AIChebyshev",
+                                     "FSAI",
+                                     "SPAI",
+                                     "TNS",
+                                     "AS",
+                                     "RAS",
+                                     "MultiColoredSGS",
+                                     "MultiColoredGS",
+                                     "MultiColoredILU",
+                                     "MultiElimination",
+                                     "VariablePreconditioner"};
+
+class parameterized_preconditioner : public testing::TestWithParam<preconditioner_tuple>
+{
+protected:
+    parameterized_preconditioner() {}
+    virtual ~parameterized_preconditioner() {}
+    virtual void SetUp() override
+    {
+        if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
+                               "ROCALUTION_EMULATION_REGRESSION",
+                               "ROCALUTION_EMULATION_EXTENDED"}))
+        {
+            GTEST_SKIP();
+        }
+    }
+
+    virtual void TearDown() {}
+};
+
+Arguments setup_preconditioner_arguments(preconditioner_tuple tup)
+{
+    Arguments arg;
+    arg.size    = std::get<0>(tup);
+    arg.precond = std::get<1>(tup);
+    return arg;
+}
+
+#define TEST_P_CASE(function, type, disable_accelerator)        \
+    disable_accelerator_rocalution(disable_accelerator);        \
+    set_device_rocalution(0);                                   \
+    init_rocalution();                                          \
+    Arguments arg = setup_preconditioner_arguments(GetParam()); \
+    function<type>(arg);                                        \
+    stop_rocalution();                                          \
+    disable_accelerator_rocalution(false);
+
+#define GENERATE_P_TEST_CASES_DEVICE(test_fixture, function, name) \
+    TEST_P(test_fixture, name##_device_float)                      \
+    {                                                              \
+        TEST_P_CASE(function, float, false);                       \
+    }                                                              \
+    TEST_P(test_fixture, name##_device_double)                     \
+    {                                                              \
+        TEST_P_CASE(function, double, false);                      \
+    }
+
+#define GENERATE_P_TEST_CASES_HOST(test_fixture, function, name) \
+    TEST_P(test_fixture, name##_host_float)                      \
+    {                                                            \
+        TEST_P_CASE(function, float, true);                      \
+    }                                                            \
+    TEST_P(test_fixture, name##_host_double)                     \
+    {                                                            \
+        TEST_P_CASE(function, double, true);                     \
+    }
+#define GENERATE_P_TEST_CASES(test_fixture, function, name)    \
+    GENERATE_P_TEST_CASES_DEVICE(test_fixture, function, name) \
+    GENERATE_P_TEST_CASES_HOST(test_fixture, function, name)
+
+GENERATE_P_TEST_CASES_DEVICE(parameterized_preconditioner, testing_preconditioner_all, all);
+
+INSTANTIATE_TEST_CASE_P(preconditioner,
+                        parameterized_preconditioner,
+                        testing::Combine(testing::ValuesIn(preconditioner_size),
+                                         testing::ValuesIn(preconditioner_type)));


### PR DESCRIPTION
This PR adds new test files for parts of the library that was less tested.

The new tests are tested if the environment variable `ROCALUTION_CODE_COVERAGE` is set to `1`.