### PR TITLE
make the existing tests run on host (for code cov) + some smaller additions

### DIFF
--- a/clients/include/testing_bicgstab.hpp
+++ b/clients/include/testing_bicgstab.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,11 +44,13 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_bicgstab(Arguments argus)
 {
-    int          ndim    = argus.size;
-    std::string  precond = argus.precond;
-    unsigned int format  = argus.format;
+    int          ndim                = argus.size;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -69,10 +71,13 @@ bool testing_bicgstab(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -148,13 +153,19 @@ bool testing_bicgstab(Arguments argus)
         ls.SetPreconditioner(*p);
     }
 
-    ls.Init(1e-8, 0.0, 1e+8, 10000);
+    ls.Init(1e-8, 0.0, 1e+8, 0, 10000);
+    ls.RecordResidualHistory();
+    auto n_iter = ls.GetIterationCount();
     ls.Build();
 
     // Matrix format
     A.ConvertTo(format, format == BCSR ? argus.blockdim : 1);
 
     ls.Solve(b, &x);
+
+    const std::string filename = "test_recorded_history.txt";
+    ls.RecordHistory(filename);
+    std::remove(filename.c_str());
 
     // Verify solution
     x.ScaleAdd(-1.0, e);
@@ -171,6 +182,7 @@ bool testing_bicgstab(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_bicgstabl.hpp
+++ b/clients/include/testing_bicgstabl.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,12 +44,14 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_bicgstabl(Arguments argus)
 {
-    int          ndim    = argus.size;
-    std::string  precond = argus.precond;
-    unsigned int format  = argus.format;
-    int          l       = argus.index;
+    int          ndim                = argus.size;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    int          l                   = argus.index;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -70,10 +72,13 @@ bool testing_bicgstabl(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -173,6 +178,7 @@ bool testing_bicgstabl(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_cg.hpp
+++ b/clients/include/testing_cg.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,11 +44,13 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_cg(Arguments argus)
 {
-    int          ndim    = argus.size;
-    std::string  precond = argus.precond;
-    unsigned int format  = argus.format;
+    int          ndim                = argus.size;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -69,10 +71,13 @@ bool testing_cg(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -171,6 +176,7 @@ bool testing_cg(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_cr.hpp
+++ b/clients/include/testing_cr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,11 +44,13 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_cr(Arguments argus)
 {
-    int          ndim    = argus.size;
-    std::string  precond = argus.precond;
-    unsigned int format  = argus.format;
+    int          ndim                = argus.size;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -69,10 +71,13 @@ bool testing_cr(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -171,6 +176,7 @@ bool testing_cr(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_fcg.hpp
+++ b/clients/include/testing_fcg.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,11 +44,13 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_fcg(Arguments argus)
 {
-    int          ndim    = argus.size;
-    std::string  precond = argus.precond;
-    unsigned int format  = argus.format;
+    int          ndim                = argus.size;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -69,10 +71,13 @@ bool testing_fcg(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -171,6 +176,7 @@ bool testing_fcg(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_fgmres.hpp
+++ b/clients/include/testing_fgmres.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,12 +34,14 @@ using namespace rocalution;
 template <typename T>
 bool testing_fgmres(Arguments argus)
 {
-    int          ndim    = argus.size;
-    int          basis   = argus.index;
-    std::string  precond = argus.precond;
-    unsigned int format  = argus.format;
+    int          ndim                = argus.size;
+    int          basis               = argus.index;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -60,10 +62,13 @@ bool testing_fgmres(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -164,6 +169,7 @@ bool testing_fgmres(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_gmres.hpp
+++ b/clients/include/testing_gmres.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,13 +34,15 @@ using namespace rocalution;
 template <typename T>
 bool testing_gmres(Arguments argus, bool expectConvergence = true)
 {
-    int          ndim    = argus.size;
-    int          basis   = argus.index;
-    std::string  matrix  = argus.matrix;
-    std::string  precond = argus.precond;
-    unsigned int format  = argus.format;
+    int          ndim                = argus.size;
+    int          basis               = argus.index;
+    std::string  matrix              = argus.matrix;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -68,10 +70,13 @@ bool testing_gmres(Arguments argus, bool expectConvergence = true)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -172,6 +177,7 @@ bool testing_gmres(Arguments argus, bool expectConvergence = true)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_idr.hpp
+++ b/clients/include/testing_idr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,12 +44,14 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_idr(Arguments argus)
 {
-    int          ndim    = argus.size;
-    std::string  precond = argus.precond;
-    unsigned int format  = argus.format;
-    int          l       = argus.index;
+    int          ndim                = argus.size;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    int          l                   = argus.index;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -70,10 +72,13 @@ bool testing_idr(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -174,6 +179,7 @@ bool testing_idr(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_inversion.hpp
+++ b/clients/include/testing_inversion.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,11 +44,13 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_inversion(Arguments argus)
 {
-    int          ndim        = argus.size;
-    unsigned int format      = argus.format;
-    std::string  matrix_type = argus.matrix_type;
+    int          ndim                = argus.size;
+    unsigned int format              = argus.format;
+    std::string  matrix_type         = argus.matrix_type;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -84,10 +86,13 @@ bool testing_inversion(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -125,6 +130,7 @@ bool testing_inversion(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_lu.hpp
+++ b/clients/include/testing_lu.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,11 +44,13 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_lu(Arguments argus)
 {
-    int          ndim        = argus.size;
-    unsigned int format      = argus.format;
-    std::string  matrix_type = argus.matrix_type;
+    int          ndim                = argus.size;
+    unsigned int format              = argus.format;
+    std::string  matrix_type         = argus.matrix_type;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -84,10 +86,13 @@ bool testing_lu(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -126,6 +131,7 @@ bool testing_lu(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_pairwise_amg.hpp
+++ b/clients/include/testing_pairwise_amg.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2022 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,15 +44,17 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_pairwise_amg(Arguments argus)
 {
-    int          ndim           = argus.size;
-    int          pre_iter       = argus.pre_smooth;
-    int          post_iter      = argus.post_smooth;
-    std::string  smoother       = argus.smoother;
-    unsigned int format         = argus.format;
-    unsigned int ordering       = argus.ordering;
-    bool         rebuildnumeric = argus.rebuildnumeric;
+    int          ndim                = argus.size;
+    int          pre_iter            = argus.pre_smooth;
+    int          post_iter           = argus.post_smooth;
+    std::string  smoother            = argus.smoother;
+    unsigned int format              = argus.format;
+    unsigned int ordering            = argus.ordering;
+    bool         rebuildnumeric      = argus.rebuildnumeric;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -88,11 +90,14 @@ bool testing_pairwise_amg(Arguments argus)
     assert(csr_val == NULL);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    b2.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        b2.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -203,6 +208,7 @@ bool testing_pairwise_amg(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     for(int i = 0; i < levels - 1; ++i)
     {
@@ -213,6 +219,278 @@ bool testing_pairwise_amg(Arguments argus)
     delete[] sm;
 
     return success;
+}
+
+template <typename T>
+bool testing_pairwise_amg_2(Arguments argus)
+{
+    int          ndim           = argus.size;
+    int          pre_iter       = argus.pre_smooth;
+    int          post_iter      = argus.post_smooth;
+    std::string  smoother       = argus.smoother;
+    unsigned int format         = argus.format;
+    unsigned int ordering       = argus.ordering;
+    bool         rebuildnumeric = argus.rebuildnumeric;
+
+    // Initialize rocALUTION platform
+    set_device_rocalution(device);
+    init_rocalution();
+
+    // rocALUTION structures
+    LocalMatrix<T> A;
+    LocalVector<T> x;
+    LocalVector<T> b;
+    LocalVector<T> b2;
+    LocalVector<T> e;
+
+    // Generate A
+    int* csr_ptr = NULL;
+    int* csr_col = NULL;
+    T*   csr_val = NULL;
+
+    int nrow = gen_2d_laplacian(ndim, &csr_ptr, &csr_col, &csr_val);
+    int nnz  = csr_ptr[nrow];
+
+    T* csr_val2 = NULL;
+    if(rebuildnumeric)
+    {
+        csr_val2 = new T[nnz];
+        for(int i = 0; i < nnz; i++)
+        {
+            csr_val2[i] = csr_val[i];
+        }
+    }
+
+    A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
+
+    assert(csr_ptr == NULL);
+    assert(csr_col == NULL);
+    assert(csr_val == NULL);
+
+    // Move data to accelerator
+    A.MoveToAccelerator();
+    x.MoveToAccelerator();
+    b.MoveToAccelerator();
+    b2.MoveToAccelerator();
+    e.MoveToAccelerator();
+
+    // Allocate x, b and e
+    x.Allocate("x", A.GetN());
+    b.Allocate("b", A.GetM());
+    b2.Allocate("b2", A.GetM());
+    e.Allocate("e", A.GetN());
+
+    // b = A * 1
+    e.Ones();
+    A.Apply(e, &b);
+
+    // Random initial guess
+    x.SetRandomUniform(12345ULL, -4.0, 6.0);
+
+    // Solver
+    CG<LocalMatrix<T>, LocalVector<T>, T> ls;
+
+    // AMG
+    PairwiseAMG<LocalMatrix<T>, LocalVector<T>, T> p;
+
+    // Setup AMG
+    p.SetOrdering(ordering);
+    p.SetCoarsestLevel(300);
+    p.SetCycle(Kcycle);
+    p.SetOperator(A);
+    p.SetManualSmoothers(false);
+    p.SetManualSolver(true);
+    p.SetBeta(0.5);
+    p.SetCoarseningFactor(1.0);
+    p.BuildHierarchy();
+
+    // Get number of hierarchy levels
+    int levels = p.GetNumLevels();
+
+    // Coarse grid solver
+    CG<LocalMatrix<T>, LocalVector<T>, T> cgs;
+    cgs.Verbose(0);
+
+    // Smoother for each level
+    IterativeLinearSolver<LocalMatrix<T>, LocalVector<T>, T>** sm
+        = new IterativeLinearSolver<LocalMatrix<T>, LocalVector<T>, T>*[levels - 1];
+
+    Preconditioner<LocalMatrix<T>, LocalVector<T>, T>** smooth
+        = new Preconditioner<LocalMatrix<T>, LocalVector<T>, T>*[levels - 1];
+
+    for(int i = 0; i < levels - 1; ++i)
+    {
+        FixedPoint<LocalMatrix<T>, LocalVector<T>, T>* fp
+            = new FixedPoint<LocalMatrix<T>, LocalVector<T>, T>;
+        sm[i] = fp;
+
+        if(smoother == "Jacobi")
+        {
+            smooth[i] = new Jacobi<LocalMatrix<T>, LocalVector<T>, T>;
+            fp->SetRelaxation(0.67);
+        }
+        else if(smoother == "MCGS")
+        {
+            smooth[i] = new MultiColoredGS<LocalMatrix<T>, LocalVector<T>, T>;
+            fp->SetRelaxation(1.3);
+        }
+        else if(smoother == "MCILU")
+            smooth[i] = new MultiColoredILU<LocalMatrix<T>, LocalVector<T>, T>;
+        else
+            return false;
+
+        sm[i]->SetPreconditioner(*(smooth[i]));
+        sm[i]->Verbose(0);
+    }
+
+    p.SetSmoother(sm);
+    p.SetSolver(cgs);
+    p.SetSmootherPreIter(pre_iter);
+    p.SetSmootherPostIter(post_iter);
+    p.SetOperatorFormat(format, (format == BCSR ? argus.blockdim : 1));
+    p.InitMaxIter(1);
+    p.Verbose(0);
+
+    ls.Verbose(0);
+    ls.SetOperator(A);
+    ls.SetPreconditioner(p);
+
+    ls.Init(1e-8, 0.0, 1e+8, 10000);
+    ls.Build();
+
+    if(rebuildnumeric)
+    {
+        A.UpdateValuesCSR(csr_val2);
+        delete[] csr_val2;
+
+        // b2 = A * 1
+        A.Apply(e, &b2);
+
+        ls.ReBuildNumeric();
+    }
+
+    // Matrix format
+    A.ConvertTo(format, format == BCSR ? argus.blockdim : 1);
+
+    ls.Solve(rebuildnumeric ? b2 : b, &x);
+
+    // Verify solution
+    x.ScaleAdd(-1.0, e);
+    T nrm2 = x.Norm();
+
+    bool success = check_residual(nrm2);
+
+    // Clean up
+    ls.Clear(); // TODO
+
+    // Stop rocALUTION platform
+    stop_rocalution();
+
+    for(int i = 0; i < levels - 1; ++i)
+    {
+        delete smooth[i];
+        delete sm[i];
+    }
+    delete[] smooth;
+    delete[] sm;
+
+    return success;
+}
+
+template <typename T>
+bool testing_pairwise_amg_3(Arguments argus)
+{
+    // Initialize rocALUTION
+    init_rocalution();
+
+    // Print rocALUTION info
+    info_rocalution();
+
+    // rocALUTION objects
+    LocalVector<T> x;
+    LocalVector<T> rhs;
+    LocalVector<T> e;
+    LocalMatrix<T> mat;
+
+    int ndim = argus.size;
+
+    // Generate A
+    int* csr_ptr = NULL;
+    int* csr_col = NULL;
+    T*   csr_val = NULL;
+
+    int nrow = gen_2d_laplacian(ndim, &csr_ptr, &csr_col, &csr_val);
+    int nnz  = csr_ptr[nrow];
+
+    T* csr_val2 = NULL;
+
+    mat.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
+
+    // Move objects to accelerator
+    mat.MoveToAccelerator();
+    x.MoveToAccelerator();
+    rhs.MoveToAccelerator();
+    e.MoveToAccelerator();
+
+    // Allocate vectors
+    x.Allocate("x", mat.GetN());
+    rhs.Allocate("rhs", mat.GetM());
+    e.Allocate("e", mat.GetN());
+
+    // Initialize rhs such that A 1 = rhs
+    e.Ones();
+    mat.Apply(e, &rhs);
+
+    // Initial zero guess
+    x.Zeros();
+
+    // Linear Solver
+    CG<LocalMatrix<T>, LocalVector<T>, T> ls;
+
+    // AMG Preconditioner
+    SAAMG<LocalMatrix<T>, LocalVector<T>, T> p;
+
+    // Disable verbosity output of AMG preconditioner
+    p.Verbose(0);
+
+    // Set solver preconditioner
+    ls.SetPreconditioner(p);
+    // Set solver operator
+    ls.SetOperator(mat);
+
+    // Build solver
+    ls.Build();
+
+    // Compute 2 coarsest levels on the host
+    p.SetHostLevels(2);
+
+    // Print matrix info
+    mat.Info();
+
+    // Initialize solver tolerances
+    ls.Init(1e-8, 1e-8, 1e+8, 10000);
+
+    // Set verbosity output
+    ls.Verbose(1);
+
+    // Solve A x = rhs
+    ls.Solve(rhs, &x);
+
+    // Clear solver
+    ls.Clear();
+
+    // Compute error L2 norm
+    e.ScaleAdd(-1.0, x);
+    T error = e.Norm();
+    std::cout << "||e - x||_2 = " << error << std::endl;
+
+    // Stop rocALUTION platform
+
+    ls.Clear();
+
+    stop_rocalution();
+
+    return true;
 }
 
 #endif // TESTING_PAIRWISE_AMG_HPP

--- a/clients/include/testing_qmrcgstab.hpp
+++ b/clients/include/testing_qmrcgstab.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,11 +44,13 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_qmrcgstab(Arguments argus)
 {
-    int          ndim    = argus.size;
-    std::string  precond = argus.precond;
-    unsigned int format  = argus.format;
+    int          ndim                = argus.size;
+    std::string  precond             = argus.precond;
+    unsigned int format              = argus.format;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -69,10 +71,13 @@ bool testing_qmrcgstab(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -171,6 +176,7 @@ bool testing_qmrcgstab(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_qr.hpp
+++ b/clients/include/testing_qr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,11 +44,13 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_qr(Arguments argus)
 {
-    int          ndim        = argus.size;
-    unsigned int format      = argus.format;
-    std::string  matrix_type = argus.matrix_type;
+    int          ndim                = argus.size;
+    unsigned int format              = argus.format;
+    std::string  matrix_type         = argus.matrix_type;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -84,10 +86,13 @@ bool testing_qr(Arguments argus)
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -125,6 +130,7 @@ bool testing_qr(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_saamg.hpp
+++ b/clients/include/testing_saamg.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,8 +54,10 @@ bool testing_saamg(Arguments argus)
     int          cycle               = argus.cycle;
     bool         scaling             = argus.ordering;
     bool         rebuildnumeric      = argus.rebuildnumeric;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -103,11 +105,14 @@ bool testing_saamg(Arguments argus)
     assert(csr_val == NULL);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    b2.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        b2.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -148,6 +153,8 @@ bool testing_saamg(Arguments argus)
     {
         return false;
     }
+
+    p.SetLumpingStrategy(LumpingStrategy::AddWeakConnections);
 
     p.SetCouplingStrength(0.001);
     p.SetInterpRelax(2.0 / 3.0);
@@ -225,6 +232,7 @@ bool testing_saamg(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     for(int i = 0; i < levels - 1; ++i)
     {

--- a/clients/include/testing_uaamg.hpp
+++ b/clients/include/testing_uaamg.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2022 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,8 +54,10 @@ bool testing_uaamg(Arguments argus)
     int          cycle               = argus.cycle;
     bool         scaling             = argus.ordering;
     bool         rebuildnumeric      = argus.rebuildnumeric;
+    bool         disable_accelerator = !argus.use_acc;
 
     // Initialize rocALUTION platform
+    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -103,11 +105,14 @@ bool testing_uaamg(Arguments argus)
     assert(csr_val == NULL);
 
     // Move data to accelerator
-    A.MoveToAccelerator();
-    x.MoveToAccelerator();
-    b.MoveToAccelerator();
-    b2.MoveToAccelerator();
-    e.MoveToAccelerator();
+    if(!disable_accelerator)
+    {
+        A.MoveToAccelerator();
+        x.MoveToAccelerator();
+        b.MoveToAccelerator();
+        b2.MoveToAccelerator();
+        e.MoveToAccelerator();
+    }
 
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
@@ -224,6 +229,7 @@ bool testing_uaamg(Arguments argus)
 
     // Stop rocALUTION platform
     stop_rocalution();
+    disable_accelerator_rocalution(false);
 
     for(int i = 0; i < levels - 1; ++i)
     {

--- a/clients/tests/test_bicgstab.cpp
+++ b/clients/tests/test_bicgstab.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,23 +27,35 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, std::string, unsigned int> bicgstab_tuple;
+typedef std::tuple<int, std::string, unsigned int, int> bicgstab_tuple;
 
 std::vector<int>         bicgstab_size = {7, 63};
 std::vector<std::string> bicgstab_precond
     = {"None", "Chebyshev", "TNS", "Jacobi", "ItILU0", "ILUT", "MCGS", "MCILU"};
-std::vector<unsigned int> bicgstab_format = {1, 2, 4, 6};
+std::vector<unsigned int> bicgstab_format  = {1, 2, 4, 6};
+std::vector<int>          bicgstab_use_acc = {1};
 
 // Function to update tests if environment variable is set
 void update_bicgstab()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         bicgstab_size.clear();
         bicgstab_precond.clear();
         bicgstab_format.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        bicgstab_size.push_back(7);
+        bicgstab_precond.insert(
+            bicgstab_precond.end(),
+            {"None", "Chebyshev", "TNS", "Jacobi", "ItILU0", "ILUT", "MCGS", "MCILU"});
+        bicgstab_format.insert(bicgstab_format.end(), {1, 2, 4, 6});
+        bicgstab_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -92,6 +104,7 @@ Arguments setup_bicgstab_arguments(bicgstab_tuple tup)
     arg.size    = std::get<0>(tup);
     arg.precond = std::get<1>(tup);
     arg.format  = std::get<2>(tup);
+    arg.use_acc = std::get<3>(tup);
     return arg;
 }
 
@@ -111,4 +124,5 @@ INSTANTIATE_TEST_CASE_P(bicgstab,
                         parameterized_bicgstab,
                         testing::Combine(testing::ValuesIn(bicgstab_size),
                                          testing::ValuesIn(bicgstab_precond),
-                                         testing::ValuesIn(bicgstab_format)));
+                                         testing::ValuesIn(bicgstab_format),
+                                         testing::ValuesIn(bicgstab_use_acc)));

--- a/clients/tests/test_bicgstabl.cpp
+++ b/clients/tests/test_bicgstabl.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,25 +27,36 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, std::string, unsigned int, int> bicgstabl_tuple;
+typedef std::tuple<int, std::string, unsigned int, int, int> bicgstabl_tuple;
 
 std::vector<int>         bicgstabl_size = {7, 63};
 std::vector<std::string> bicgstabl_precond
     = {"None", "SPAI", "TNS", "Jacobi", "GS", "ILU", "ItILU0", "ILUT", "IC", "MCGS", "MCILU"};
-std::vector<unsigned int> bicgstabl_format = {1, 4, 5, 6, 7};
-std::vector<int>          bicgstabl_level  = {1, 2, 4};
+std::vector<unsigned int> bicgstabl_format  = {1, 4, 5, 6, 7};
+std::vector<int>          bicgstabl_level   = {1, 2, 4};
+std::vector<int>          bicgstabl_use_acc = {1};
 
 // Function to update tests if environment variable is set
 void update_bicgstabl()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         bicgstabl_size.clear();
         bicgstabl_precond.clear();
         bicgstabl_format.clear();
         bicgstabl_level.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        bicgstabl_size.push_back(7);
+        bicgstabl_precond.insert(bicgstabl_precond.end(), {"None", "Jacobi"});
+        bicgstabl_format.push_back(1);
+        bicgstabl_level.push_back(1);
+        bicgstabl_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -98,6 +109,7 @@ Arguments setup_bicgstabl_arguments(bicgstabl_tuple tup)
     arg.precond = std::get<1>(tup);
     arg.format  = std::get<2>(tup);
     arg.index   = std::get<3>(tup);
+    arg.use_acc = std::get<4>(tup);
     return arg;
 }
 
@@ -118,4 +130,5 @@ INSTANTIATE_TEST_CASE_P(bicgstabl,
                         testing::Combine(testing::ValuesIn(bicgstabl_size),
                                          testing::ValuesIn(bicgstabl_precond),
                                          testing::ValuesIn(bicgstabl_format),
-                                         testing::ValuesIn(bicgstabl_level)));
+                                         testing::ValuesIn(bicgstabl_level),
+                                         testing::ValuesIn(bicgstabl_use_acc)));

--- a/clients/tests/test_cg.cpp
+++ b/clients/tests/test_cg.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,22 +27,33 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, std::string, unsigned int> cg_tuple;
+typedef std::tuple<int, std::string, unsigned int, int> cg_tuple;
 
 std::vector<int>          cg_size    = {7, 63};
 std::vector<std::string>  cg_precond = {"None", "FSAI", "SPAI", "TNS", "Jacobi", "IC", "MCSGS"};
 std::vector<unsigned int> cg_format  = {1, 3, 4, 6};
+std::vector<int>          cg_use_acc = {1};
 
 // Function to update tests if environment variable is set
 void update_cg()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         cg_size.clear();
         cg_precond.clear();
         cg_format.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        cg_size.push_back(7);
+        cg_precond.insert(cg_precond.end(),
+                          {"None", "FSAI", "SPAI", "TNS", "Jacobi", "IC", "MCSGS"});
+        cg_format.insert(cg_format.end(), {1, 3, 4, 6});
+        cg_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -91,6 +102,7 @@ Arguments setup_cg_arguments(cg_tuple tup)
     arg.size    = std::get<0>(tup);
     arg.precond = std::get<1>(tup);
     arg.format  = std::get<2>(tup);
+    arg.use_acc = std::get<3>(tup);
     return arg;
 }
 
@@ -110,4 +122,5 @@ INSTANTIATE_TEST_CASE_P(cg,
                         parameterized_cg,
                         testing::Combine(testing::ValuesIn(cg_size),
                                          testing::ValuesIn(cg_precond),
-                                         testing::ValuesIn(cg_format)));
+                                         testing::ValuesIn(cg_format),
+                                         testing::ValuesIn(cg_use_acc)));

--- a/clients/tests/test_cr.cpp
+++ b/clients/tests/test_cr.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,23 +27,35 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, std::string, unsigned int> cr_tuple;
+typedef std::tuple<int, std::string, unsigned int, int> cr_tuple;
 
 std::vector<int>         cr_size = {7, 63};
 std::vector<std::string> cr_precond
     = {"None", "Chebyshev", "FSAI", "Jacobi", "SGS", "ILU", "ItILU0", "IC", "MCSGS"};
-std::vector<unsigned int> cr_format = {2, 4, 7};
+std::vector<unsigned int> cr_format  = {2, 4, 7};
+std::vector<int>          cr_use_acc = {1};
 
 // Function to update tests if environment variable is set
 void update_cr()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         cr_size.clear();
         cr_precond.clear();
         cr_format.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        cr_size.push_back(7);
+        cr_precond.insert(
+            cr_precond.end(),
+            {"None", "Chebyshev", "FSAI", "Jacobi", "SGS", "ILU", "ItILU0", "IC", "MCSGS"});
+        cr_format.insert(cr_format.end(), {2, 4, 7});
+        cr_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -92,6 +104,7 @@ Arguments setup_cr_arguments(cr_tuple tup)
     arg.size    = std::get<0>(tup);
     arg.precond = std::get<1>(tup);
     arg.format  = std::get<2>(tup);
+    arg.use_acc = std::get<3>(tup);
     return arg;
 }
 /* TODO there _MIGHT_ be some issue with float accuracy
@@ -111,4 +124,5 @@ INSTANTIATE_TEST_CASE_P(cr,
                         parameterized_cr,
                         testing::Combine(testing::ValuesIn(cr_size),
                                          testing::ValuesIn(cr_precond),
-                                         testing::ValuesIn(cr_format)));
+                                         testing::ValuesIn(cr_format),
+                                         testing::ValuesIn(cr_use_acc)));

--- a/clients/tests/test_fcg.cpp
+++ b/clients/tests/test_fcg.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,23 +27,34 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, std::string, unsigned int> fcg_tuple;
+typedef std::tuple<int, std::string, unsigned int, int> fcg_tuple;
 
 std::vector<int>         fcg_size = {7, 63};
 std::vector<std::string> fcg_precond
     = {"None", "Chebyshev", "SPAI", "TNS", "ItILU0", "ILUT", "MCSGS"};
-std::vector<unsigned int> fcg_format = {2, 5, 6, 7};
+std::vector<unsigned int> fcg_format  = {2, 5, 6, 7};
+std::vector<int>          fcg_use_acc = {1};
 
 // Function to update tests if environment variable is set
 void update_fcg()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         fcg_size.clear();
         fcg_precond.clear();
         fcg_format.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        fcg_size.push_back(7);
+        fcg_precond.insert(fcg_precond.end(),
+                           {"None", "Chebyshev", "SPAI", "TNS", "ItILU0", "ILUT", "MCSGS"});
+        fcg_format.insert(fcg_format.end(), {2, 5, 6, 7});
+        fcg_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -92,6 +103,7 @@ Arguments setup_fcg_arguments(fcg_tuple tup)
     arg.size    = std::get<0>(tup);
     arg.precond = std::get<1>(tup);
     arg.format  = std::get<2>(tup);
+    arg.use_acc = std::get<3>(tup);
     return arg;
 }
 
@@ -111,4 +123,5 @@ INSTANTIATE_TEST_CASE_P(fcg,
                         parameterized_fcg,
                         testing::Combine(testing::ValuesIn(fcg_size),
                                          testing::ValuesIn(fcg_precond),
-                                         testing::ValuesIn(fcg_format)));
+                                         testing::ValuesIn(fcg_format),
+                                         testing::ValuesIn(fcg_use_acc)));

--- a/clients/tests/test_fgmres.cpp
+++ b/clients/tests/test_fgmres.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,24 +27,36 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, int, std::string, unsigned int> fgmres_tuple;
+typedef std::tuple<int, int, std::string, unsigned int, int> fgmres_tuple;
 
 std::vector<int>          fgmres_size    = {7, 63};
 std::vector<int>          fgmres_basis   = {20, 60};
 std::vector<std::string>  fgmres_precond = {"None", "SPAI", "TNS", "Jacobi", "GS", "ILUT", "MCGS"};
 std::vector<unsigned int> fgmres_format  = {1, 4, 5, 7};
+std::vector<int>          fgmres_use_acc = {1};
 
 // Function to update tests if environment variable is set
 void update_fgmres()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         fgmres_size.clear();
         fgmres_basis.clear();
         fgmres_precond.clear();
         fgmres_format.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        fgmres_size.push_back(7);
+        fgmres_basis.push_back(20);
+        fgmres_precond.insert(fgmres_precond.end(),
+                              {"None", "SPAI", "TNS", "Jacobi", "GS", "ILUT", "MCGS"});
+        fgmres_format.insert(fgmres_format.end(), {1, 4, 5, 7});
+        fgmres_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -97,6 +109,7 @@ Arguments setup_fgmres_arguments(fgmres_tuple tup)
     arg.index   = std::get<1>(tup);
     arg.precond = std::get<2>(tup);
     arg.format  = std::get<3>(tup);
+    arg.use_acc = std::get<4>(tup);
     return arg;
 }
 
@@ -117,4 +130,5 @@ INSTANTIATE_TEST_CASE_P(fgmres,
                         testing::Combine(testing::ValuesIn(fgmres_size),
                                          testing::ValuesIn(fgmres_basis),
                                          testing::ValuesIn(fgmres_precond),
-                                         testing::ValuesIn(fgmres_format)));
+                                         testing::ValuesIn(fgmres_format),
+                                         testing::ValuesIn(fgmres_use_acc)));

--- a/clients/tests/test_idr.cpp
+++ b/clients/tests/test_idr.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,24 +27,35 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, std::string, unsigned int, int> idr_tuple;
+typedef std::tuple<int, std::string, unsigned int, int, int> idr_tuple;
 
 std::vector<int>          idr_size    = {7, 63};
 std::vector<std::string>  idr_precond = {"None", "SPAI", "GS", "ILU", "MCILU"};
 std::vector<unsigned int> idr_format  = {1, 4, 5, 6};
 std::vector<int>          idr_level   = {1, 2};
+std::vector<int>          idr_use_acc = {1};
 
 // Function to update tests if environment variable is set
 void update_idr()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         idr_size.clear();
         idr_precond.clear();
         idr_format.clear();
         idr_level.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        idr_size.push_back(7);
+        idr_precond.insert(idr_precond.end(), {"None", "SPAI", "GS", "ILU", "MCILU"});
+        idr_format.insert(idr_format.end(), {1, 4, 5, 6});
+        idr_level.insert(idr_level.end(), {1, 2});
+        idr_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -97,6 +108,7 @@ Arguments setup_idr_arguments(idr_tuple tup)
     arg.precond = std::get<1>(tup);
     arg.format  = std::get<2>(tup);
     arg.index   = std::get<3>(tup);
+    arg.use_acc = std::get<4>(tup);
     return arg;
 }
 
@@ -117,4 +129,5 @@ INSTANTIATE_TEST_CASE_P(idr,
                         testing::Combine(testing::ValuesIn(idr_size),
                                          testing::ValuesIn(idr_precond),
                                          testing::ValuesIn(idr_format),
-                                         testing::ValuesIn(idr_level)));
+                                         testing::ValuesIn(idr_level),
+                                         testing::ValuesIn(idr_use_acc)));

--- a/clients/tests/test_inversion.cpp
+++ b/clients/tests/test_inversion.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,22 +27,32 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, unsigned int, std::string> inversion_tuple;
+typedef std::tuple<int, unsigned int, std::string, int> inversion_tuple;
 
 std::vector<int>          inversion_size        = {7, 16, 21};
 std::vector<unsigned int> inversion_format      = {1, 2, 3, 4, 5, 6, 7};
 std::vector<std::string>  inversion_matrix_type = {"Laplacian2D", "PermutedIdentity"};
+std::vector<int>          inversion_use_acc     = {1};
 
 // Function to update tests if environment variable is set
 void update_inversion()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         inversion_size.clear();
         inversion_format.clear();
         inversion_matrix_type.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        inversion_size.push_back(7);
+        inversion_format.insert(inversion_format.end(), {1, 2, 3, 4, 5, 6, 7});
+        inversion_matrix_type.push_back("Laplacian2D");
+        inversion_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -93,6 +103,7 @@ Arguments setup_inversion_arguments(inversion_tuple tup)
     arg.size        = std::get<0>(tup);
     arg.format      = std::get<1>(tup);
     arg.matrix_type = std::get<2>(tup);
+    arg.use_acc     = std::get<3>(tup);
     return arg;
 }
 
@@ -112,4 +123,5 @@ INSTANTIATE_TEST_CASE_P(inversion,
                         parameterized_inversion,
                         testing::Combine(testing::ValuesIn(inversion_size),
                                          testing::ValuesIn(inversion_format),
-                                         testing::ValuesIn(inversion_matrix_type)));
+                                         testing::ValuesIn(inversion_matrix_type),
+                                         testing::ValuesIn(inversion_use_acc)));

--- a/clients/tests/test_lu.cpp
+++ b/clients/tests/test_lu.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,24 +27,36 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, unsigned int, std::string> lu_tuple;
+typedef std::tuple<int, unsigned int, std::string, int> lu_tuple;
 
 std::vector<int>          lu_size        = {7, 16, 21};
 std::vector<unsigned int> lu_format      = {1, 2, 3, 4, 5, 6, 7};
 std::vector<std::string>  lu_matrix_type = {"Laplacian2D"};
+std::vector<int>          lu_use_acc     = {1};
 
 // Function to update tests if environment variable is set
 void update_lu()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         lu_size.clear();
         lu_format.clear();
 
         lu_size.push_back(16);
         lu_format.push_back(2);
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        lu_size.clear();
+        lu_format.clear();
+
+        lu_size.push_back(7);
+        lu_format.insert(lu_format.end(), {1, 2, 3, 4, 5, 6, 7});
+        lu_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -90,6 +102,7 @@ Arguments setup_lu_arguments(lu_tuple tup)
     arg.size        = std::get<0>(tup);
     arg.format      = std::get<1>(tup);
     arg.matrix_type = std::get<2>(tup);
+    arg.use_acc     = std::get<3>(tup);
     return arg;
 }
 
@@ -109,4 +122,5 @@ INSTANTIATE_TEST_CASE_P(lu,
                         parameterized_lu,
                         testing::Combine(testing::ValuesIn(lu_size),
                                          testing::ValuesIn(lu_format),
-                                         testing::ValuesIn(lu_matrix_type)));
+                                         testing::ValuesIn(lu_matrix_type),
+                                         testing::ValuesIn(lu_use_acc)));

--- a/clients/tests/test_qmrcgstab.cpp
+++ b/clients/tests/test_qmrcgstab.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,23 +27,34 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, std::string, unsigned int> qmrcgstab_tuple;
+typedef std::tuple<int, std::string, unsigned int, int> qmrcgstab_tuple;
 
 std::vector<int>         qmrcgstab_size = {7, 63};
 std::vector<std::string> qmrcgstab_precond
     = {"None", "Chebyshev", "SPAI", "Jacobi", "GS", "ILU", "ItILU0"};
-std::vector<unsigned int> qmrcgstab_format = {1, 2, 3, 7};
+std::vector<unsigned int> qmrcgstab_format  = {1, 2, 3, 7};
+std::vector<int>          qmrcgstab_use_acc = {1};
 
 // Function to update tests if environment variable is set
 void update_qmrcgstab()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         qmrcgstab_size.clear();
         qmrcgstab_precond.clear();
         qmrcgstab_format.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        qmrcgstab_size.push_back(7);
+        qmrcgstab_precond.insert(qmrcgstab_precond.end(),
+                                 {"None", "Chebyshev", "SPAI", "Jacobi", "GS", "ILU", "ItILU0"});
+        qmrcgstab_format.insert(qmrcgstab_format.end(), {1, 2, 3, 7});
+        qmrcgstab_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -92,6 +103,7 @@ Arguments setup_qmrcgstab_arguments(qmrcgstab_tuple tup)
     arg.size    = std::get<0>(tup);
     arg.precond = std::get<1>(tup);
     arg.format  = std::get<2>(tup);
+    arg.use_acc = std::get<3>(tup);
     return arg;
 }
 
@@ -111,4 +123,5 @@ INSTANTIATE_TEST_CASE_P(qmrcgstab,
                         parameterized_qmrcgstab,
                         testing::Combine(testing::ValuesIn(qmrcgstab_size),
                                          testing::ValuesIn(qmrcgstab_precond),
-                                         testing::ValuesIn(qmrcgstab_format)));
+                                         testing::ValuesIn(qmrcgstab_format),
+                                         testing::ValuesIn(qmrcgstab_use_acc)));

--- a/clients/tests/test_qr.cpp
+++ b/clients/tests/test_qr.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,22 +27,32 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, unsigned int, std::string> qr_tuple;
+typedef std::tuple<int, unsigned int, std::string, int> qr_tuple;
 
 std::vector<int>          qr_size        = {7, 16, 21};
 std::vector<unsigned int> qr_format      = {1, 2, 3, 4, 5, 6, 7};
 std::vector<std::string>  qr_matrix_type = {"Laplacian2D", "PermutedIdentity"};
+std::vector<int>          qr_use_acc     = {1};
 
 // Function to update tests if environment variable is set
 void update_qr()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         qr_size.clear();
         qr_format.clear();
         qr_matrix_type.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        qr_size.push_back(7);
+        qr_format.insert(qr_format.end(), {1, 2, 3, 4, 5, 6, 7});
+        qr_matrix_type.push_back("Laplacian2D");
+        qr_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -91,6 +101,7 @@ Arguments setup_qr_arguments(qr_tuple tup)
     arg.size        = std::get<0>(tup);
     arg.format      = std::get<1>(tup);
     arg.matrix_type = std::get<2>(tup);
+    arg.use_acc     = std::get<3>(tup);
     return arg;
 }
 
@@ -110,4 +121,5 @@ INSTANTIATE_TEST_CASE_P(qr,
                         parameterized_qr,
                         testing::Combine(testing::ValuesIn(qr_size),
                                          testing::ValuesIn(qr_format),
-                                         testing::ValuesIn(qr_matrix_type)));
+                                         testing::ValuesIn(qr_matrix_type),
+                                         testing::ValuesIn(qr_use_acc)));

--- a/clients/tests/test_ruge_stueben_amg.cpp
+++ b/clients/tests/test_ruge_stueben_amg.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,23 +27,27 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-typedef std::tuple<int, std::string, unsigned int, int, int, int, int, int> rsamg_tuple;
+typedef std::tuple<int, std::string, unsigned int, int, int, int, int, int, int, std::string>
+    rsamg_tuple;
 
-std::vector<int>          rsamg_size           = {63, 134};
-std::vector<std::string>  rsamg_smoother       = {"Jacobi"};
-std::vector<unsigned int> rsamg_format         = {1, 7};
-std::vector<int>          rsamg_pre_iter       = {1, 2};
-std::vector<int>          rsamg_post_iter      = {1, 2};
-std::vector<int>          rsamg_cycle          = {0, 1};
-std::vector<int>          rsamg_scaling        = {0, 1};
-std::vector<int>          rsamg_rebuildnumeric = {0, 1};
+std::vector<int>          rsamg_size                = {63, 134};
+std::vector<std::string>  rsamg_smoother            = {"Jacobi"};
+std::vector<unsigned int> rsamg_format              = {1, 7};
+std::vector<int>          rsamg_pre_iter            = {1, 2};
+std::vector<int>          rsamg_post_iter           = {1, 2};
+std::vector<int>          rsamg_cycle               = {0, 1};
+std::vector<int>          rsamg_scaling             = {0, 1};
+std::vector<int>          rsamg_rebuildnumeric      = {0, 1};
+std::vector<int>          rsamg_use_acc             = {1};
+std::vector<std::string>  rsamg_coarsening_strategy = {"PMIS"};
 
 // Function to update tests if environment variable is set
 void update_rsamg()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         rsamg_size.clear();
         rsamg_smoother.clear();
@@ -53,6 +57,20 @@ void update_rsamg()
         rsamg_cycle.clear();
         rsamg_scaling.clear();
         rsamg_rebuildnumeric.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        rsamg_size.push_back(63);
+        rsamg_smoother.push_back("Jacobi");
+        rsamg_format.insert(rsamg_format.end(), {1, 7});
+        rsamg_pre_iter.insert(rsamg_pre_iter.end(), {1, 2});
+        rsamg_post_iter.insert(rsamg_post_iter.end(), {1, 2});
+        rsamg_cycle.insert(rsamg_cycle.end(), {0, 1});
+        rsamg_scaling.insert(rsamg_scaling.end(), {0, 1});
+        rsamg_rebuildnumeric.insert(rsamg_rebuildnumeric.end(), {0, 1});
+        rsamg_use_acc.push_back(0);
+        rsamg_coarsening_strategy.push_back("Greedy");
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -113,14 +131,16 @@ protected:
 Arguments setup_rsamg_arguments(rsamg_tuple tup)
 {
     Arguments arg;
-    arg.size           = std::get<0>(tup);
-    arg.smoother       = std::get<1>(tup);
-    arg.format         = std::get<2>(tup);
-    arg.pre_smooth     = std::get<3>(tup);
-    arg.post_smooth    = std::get<4>(tup);
-    arg.cycle          = std::get<5>(tup);
-    arg.ordering       = std::get<6>(tup);
-    arg.rebuildnumeric = std::get<7>(tup);
+    arg.size                = std::get<0>(tup);
+    arg.smoother            = std::get<1>(tup);
+    arg.format              = std::get<2>(tup);
+    arg.pre_smooth          = std::get<3>(tup);
+    arg.post_smooth         = std::get<4>(tup);
+    arg.cycle               = std::get<5>(tup);
+    arg.ordering            = std::get<6>(tup);
+    arg.rebuildnumeric      = std::get<7>(tup);
+    arg.use_acc             = std::get<8>(tup);
+    arg.coarsening_strategy = std::get<9>(tup);
     return arg;
 }
 
@@ -145,4 +165,6 @@ INSTANTIATE_TEST_CASE_P(ruge_stueben_amg,
                                          testing::ValuesIn(rsamg_post_iter),
                                          testing::ValuesIn(rsamg_cycle),
                                          testing::ValuesIn(rsamg_scaling),
-                                         testing::ValuesIn(rsamg_rebuildnumeric)));
+                                         testing::ValuesIn(rsamg_rebuildnumeric),
+                                         testing::ValuesIn(rsamg_use_acc),
+                                         testing::ValuesIn(rsamg_coarsening_strategy)));

--- a/clients/tests/test_saamg.cpp
+++ b/clients/tests/test_saamg.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@
 #include <vector>
 
 typedef std::
-    tuple<int, int, int, std::string, std::string, std::string, unsigned int, int, int, int>
+    tuple<int, int, int, std::string, std::string, std::string, unsigned int, int, int, int, int>
         saamg_tuple;
 
 std::vector<int>          saamg_size             = {22, 63, 134, 207};
@@ -41,13 +41,15 @@ std::vector<unsigned int> saamg_format           = {1, 6};
 std::vector<int>          saamg_cycle            = {2};
 std::vector<int>          saamg_scaling          = {1};
 std::vector<int>          saamg_rebuildnumeric   = {0, 1};
+std::vector<int>          saamg_use_acc          = {1};
 
 // Function to update tests if environment variable is set
 void update_saamg()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         saamg_size.clear();
         saamg_smoother.clear();
@@ -58,6 +60,20 @@ void update_saamg()
         saamg_scaling.clear();
         saamg_rebuildnumeric.clear();
         saamg_coarsening_strat.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        saamg_size.push_back(22);
+        saamg_smoother.insert(saamg_smoother.end(), {"FSAI", "SPAI"});
+        saamg_format.insert(saamg_format.end(), {1, 6});
+        saamg_pre_iter.push_back(2);
+        saamg_post_iter.push_back(2);
+        saamg_cycle.push_back(2);
+        saamg_scaling.push_back(1);
+        saamg_rebuildnumeric.insert(saamg_rebuildnumeric.end(), {0, 1});
+        saamg_coarsening_strat.insert(saamg_coarsening_strat.end(), {"Greedy", "PMIS"});
+        saamg_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -131,6 +147,7 @@ Arguments setup_saamg_arguments(saamg_tuple tup)
     arg.cycle               = std::get<7>(tup);
     arg.ordering            = std::get<8>(tup);
     arg.rebuildnumeric      = std::get<9>(tup);
+    arg.use_acc             = std::get<10>(tup);
 
     return arg;
 }
@@ -158,4 +175,5 @@ INSTANTIATE_TEST_CASE_P(saamg,
                                          testing::ValuesIn(saamg_format),
                                          testing::ValuesIn(saamg_cycle),
                                          testing::ValuesIn(saamg_scaling),
-                                         testing::ValuesIn(saamg_rebuildnumeric)));
+                                         testing::ValuesIn(saamg_rebuildnumeric),
+                                         testing::ValuesIn(saamg_use_acc)));

--- a/clients/tests/test_uaamg.cpp
+++ b/clients/tests/test_uaamg.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@
 #include <vector>
 
 typedef std::
-    tuple<int, int, int, std::string, std::string, std::string, unsigned int, int, int, int>
+    tuple<int, int, int, std::string, std::string, std::string, unsigned int, int, int, int, int>
         uaamg_tuple;
 
 std::vector<int>          uaamg_size             = {22, 63, 134, 157};
@@ -41,13 +41,15 @@ std::vector<unsigned int> uaamg_format           = {1, 6};
 std::vector<int>          uaamg_cycle            = {2};
 std::vector<int>          uaamg_scaling          = {1};
 std::vector<int>          uaamg_rebuildnumeric   = {0, 1};
+std::vector<int>          uaamg_use_acc          = {1};
 
 // Function to update tests if environment variable is set
 void update_uaamg()
 {
     if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
                            "ROCALUTION_EMULATION_REGRESSION",
-                           "ROCALUTION_EMULATION_EXTENDED"}))
+                           "ROCALUTION_EMULATION_EXTENDED",
+                           "ROCALUTION_CODE_COVERAGE"}))
     {
         uaamg_size.clear();
         uaamg_smoother.clear();
@@ -58,6 +60,20 @@ void update_uaamg()
         uaamg_scaling.clear();
         uaamg_rebuildnumeric.clear();
         uaamg_coarsening_strat.clear();
+    }
+
+    if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
+    {
+        uaamg_size.push_back(22);
+        uaamg_smoother.push_back("FSAI");
+        uaamg_format.insert(uaamg_format.end(), {1, 6});
+        uaamg_pre_iter.push_back(2);
+        uaamg_post_iter.push_back(2);
+        uaamg_cycle.push_back(2);
+        uaamg_scaling.push_back(1);
+        uaamg_rebuildnumeric.insert(uaamg_rebuildnumeric.end(), {0, 1});
+        uaamg_coarsening_strat.insert(uaamg_coarsening_strat.end(), {"Greedy", "PMIS"});
+        uaamg_use_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -131,6 +147,7 @@ Arguments setup_uaamg_arguments(uaamg_tuple tup)
     arg.cycle               = std::get<7>(tup);
     arg.ordering            = std::get<8>(tup);
     arg.rebuildnumeric      = std::get<9>(tup);
+    arg.use_acc             = std::get<10>(tup);
 
     return arg;
 }
@@ -158,4 +175,5 @@ INSTANTIATE_TEST_CASE_P(uaamg,
                                          testing::ValuesIn(uaamg_format),
                                          testing::ValuesIn(uaamg_cycle),
                                          testing::ValuesIn(uaamg_scaling),
-                                         testing::ValuesIn(uaamg_rebuildnumeric)));
+                                         testing::ValuesIn(uaamg_rebuildnumeric),
+                                         testing::ValuesIn(uaamg_use_acc)));


### PR DESCRIPTION
The existing tests were run on the accelerator by default (if the build of rocALUTION for accelerator is enabled).
This implied that most of the tests were not run on the host and not contributing to the code coverage report.

Now, when `ROCALUTION_CODE_COVERAGE=1`, the tests are run on the host.

This PR also added some smaller modifications to tests:
- testing_pairwise_amg
- testing_ruge_stueben_amg