### PR TITLE
remove prec->MoveTo*() except in Solver::MoveTo*()

### DIFF
--- a/clients/include/testing_preconditioner.hpp
+++ b/clients/include/testing_preconditioner.hpp
@@ -325,7 +325,6 @@ void testing_preconditioner_all(Arguments argus)
     e.Allocate("e", matrix.GetM());
 
     ls.MoveToAccelerator();
-    p->MoveToAccelerator();
     matrix.MoveToAccelerator();
     x_acc.MoveToAccelerator();
     b.MoveToAccelerator();
@@ -344,7 +343,6 @@ void testing_preconditioner_all(Arguments argus)
     }
 
     ls.MoveToHost();
-    p->MoveToHost();
     matrix.MoveToHost();
     x_acc.MoveToHost();
     e.MoveToHost();

--- a/src/solvers/krylov/cg.cpp
+++ b/src/solvers/krylov/cg.cpp
@@ -262,7 +262,6 @@ namespace rocalution
             if(this->precond_ != NULL)
             {
                 this->z_.MoveToHost();
-                this->precond_->MoveToHost();
             }
         }
     }
@@ -281,7 +280,6 @@ namespace rocalution
             if(this->precond_ != NULL)
             {
                 this->z_.MoveToAccelerator();
-                this->precond_->MoveToAccelerator();
             }
         }
     }

--- a/src/solvers/krylov/cr.cpp
+++ b/src/solvers/krylov/cr.cpp
@@ -212,7 +212,6 @@ namespace rocalution
             {
                 this->z_.MoveToHost();
                 this->t_.MoveToHost();
-                this->precond_->MoveToHost();
             }
         }
     }
@@ -233,7 +232,6 @@ namespace rocalution
             {
                 this->z_.MoveToAccelerator();
                 this->t_.MoveToAccelerator();
-                this->precond_->MoveToAccelerator();
             }
         }
     }

--- a/src/solvers/krylov/fcg.cpp
+++ b/src/solvers/krylov/fcg.cpp
@@ -206,7 +206,6 @@ namespace rocalution
             if(this->precond_ != NULL)
             {
                 this->z_.MoveToHost();
-                this->precond_->MoveToHost();
             }
         }
     }
@@ -226,7 +225,6 @@ namespace rocalution
             if(this->precond_ != NULL)
             {
                 this->z_.MoveToAccelerator();
-                this->precond_->MoveToAccelerator();
             }
         }
     }

--- a/src/solvers/krylov/fgmres.cpp
+++ b/src/solvers/krylov/fgmres.cpp
@@ -248,8 +248,6 @@ namespace rocalution
                 {
                     this->z_[i]->MoveToHost();
                 }
-
-                this->precond_->MoveToHost();
             }
         }
     }
@@ -272,7 +270,6 @@ namespace rocalution
                 {
                     this->z_[i]->MoveToAccelerator();
                 }
-                this->precond_->MoveToAccelerator();
             }
         }
     }

--- a/src/solvers/krylov/gmres.cpp
+++ b/src/solvers/krylov/gmres.cpp
@@ -233,7 +233,6 @@ namespace rocalution
             if(this->precond_ != NULL)
             {
                 this->z_.MoveToHost();
-                this->precond_->MoveToHost();
             }
         }
     }
@@ -253,7 +252,6 @@ namespace rocalution
             if(this->precond_ != NULL)
             {
                 this->z_.MoveToAccelerator();
-                this->precond_->MoveToAccelerator();
             }
         }
     }

--- a/src/solvers/multigrid/base_multigrid.cpp
+++ b/src/solvers/multigrid/base_multigrid.cpp
@@ -474,11 +474,6 @@ namespace rocalution
                     this->q_level_[i]->MoveToHost();
                 }
             }
-
-            if(this->precond_ != NULL)
-            {
-                this->precond_->MoveToHost();
-            }
         }
     }
 
@@ -551,11 +546,6 @@ namespace rocalution
                         this->q_level_[i]->MoveToAccelerator();
                     }
                 }
-            }
-
-            if(this->precond_ != NULL)
-            {
-                this->precond_->MoveToAccelerator();
             }
         }
     }


### PR DESCRIPTION
Some tests in CI failed as follows:

```
[ RUN      ] preconditioner/parameterized_preconditioner.all_device_float/3
The default OS thread affinity configuration will be used
Number of HIP devices in the system: 1
Testing preconditioner: ILU
Matrix size: 49 x 49
ILU(0) preconditioner
ILU nnz = 217
rocalution-test: /var/jenkins_home/workspace/ecov_rocALUTION-internal_develop/uY1B6kISo/rocalution/src/base/hip/hip_matrix_csr.cpp:1605: virtual void rocalution::HIPAcceleratorMatrixCSR<float>::LUAnalyse() [ValueType = float]: Assertion `this->tmp_vec_ == NULL' failed.
Aborted (core dumped)
```

Because the `LUAnalyse` has been launched multiple times (one time per `prec->MoveToAccelerator()` for a total of 3 times).

This PR removes the duplicate calls to  `MoveToAccelerator()` for the preconditioner.