### PR TITLE
run direct solvers on both host and device within the same test

### DIFF
--- a/clients/include/testing_inversion.hpp
+++ b/clients/include/testing_inversion.hpp
@@ -44,13 +44,12 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_inversion(Arguments argus)
 {
-    int          ndim                = argus.size;
-    unsigned int format              = argus.format;
-    std::string  matrix_type         = argus.matrix_type;
-    bool         disable_accelerator = !argus.use_acc;
+    int          ndim             = argus.size;
+    unsigned int format           = argus.format;
+    std::string  matrix_type      = argus.matrix_type;
+    const bool   use_host_and_acc = argus.use_acc;
 
     // Initialize rocALUTION platform
-    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -85,15 +84,6 @@ bool testing_inversion(Arguments argus)
 
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
-    // Move data to accelerator
-    if(!disable_accelerator)
-    {
-        A.MoveToAccelerator();
-        x.MoveToAccelerator();
-        b.MoveToAccelerator();
-        e.MoveToAccelerator();
-    }
-
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
     b.Allocate("b", A.GetM());
@@ -117,20 +107,43 @@ bool testing_inversion(Arguments argus)
     // Matrix format
     A.ConvertTo(format, format == BCSR ? argus.blockdim : 1);
 
+    // Move data to accelerator
+    dls.MoveToAccelerator();
+    A.MoveToAccelerator();
+    x.MoveToAccelerator();
+    b.MoveToAccelerator();
+    e.MoveToAccelerator();
+
     dls.Solve(b, &x);
 
     // Verify solution
     x.ScaleAdd(-1.0, e);
-    T nrm2 = x.Norm();
+    T nrm2_acc = x.Norm();
 
-    bool success = check_residual(nrm2);
+    bool success = check_residual(nrm2_acc);
+
+    if(use_host_and_acc)
+    {
+        dls.MoveToHost();
+        A.MoveToHost();
+        x.MoveToHost();
+        e.MoveToHost();
+        b.MoveToHost();
+
+        dls.Solve(b, &x);
+
+        // Verify solution
+        x.ScaleAdd(-1.0, e);
+        T nrm2_host = x.Norm();
+
+        success = success && check_residual(nrm2_host);
+    }
 
     // Clean up
     dls.Clear();
 
     // Stop rocALUTION platform
     stop_rocalution();
-    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/include/testing_lu.hpp
+++ b/clients/include/testing_lu.hpp
@@ -44,13 +44,12 @@ static bool check_residual(double res)
 template <typename T>
 bool testing_lu(Arguments argus)
 {
-    int          ndim                = argus.size;
-    unsigned int format              = argus.format;
-    std::string  matrix_type         = argus.matrix_type;
-    bool         disable_accelerator = !argus.use_acc;
+    int          ndim             = argus.size;
+    unsigned int format           = argus.format;
+    std::string  matrix_type      = argus.matrix_type;
+    const bool   use_host_and_acc = argus.use_acc;
 
     // Initialize rocALUTION platform
-    disable_accelerator_rocalution(disable_accelerator);
     set_device_rocalution(device);
     init_rocalution();
 
@@ -85,15 +84,6 @@ bool testing_lu(Arguments argus)
 
     A.SetDataPtrCSR(&csr_ptr, &csr_col, &csr_val, "A", nnz, nrow, nrow);
 
-    // Move data to accelerator
-    if(!disable_accelerator)
-    {
-        A.MoveToAccelerator();
-        x.MoveToAccelerator();
-        b.MoveToAccelerator();
-        e.MoveToAccelerator();
-    }
-
     // Allocate x, b and e
     x.Allocate("x", A.GetN());
     b.Allocate("b", A.GetM());
@@ -118,20 +108,42 @@ bool testing_lu(Arguments argus)
     // Matrix format
     A.ConvertTo(format, format == BCSR ? argus.blockdim : 1);
 
+    // Move data to accelerator
+    dls.MoveToAccelerator();
+    A.MoveToAccelerator();
+    x.MoveToAccelerator();
+    b.MoveToAccelerator();
+    e.MoveToAccelerator();
+
     dls.Solve(b, &x);
 
     // Verify solution
     x.ScaleAdd(-1.0, e);
-    T nrm2 = x.Norm();
+    T nrm2_acc = x.Norm();
 
-    bool success = check_residual(nrm2);
+    bool success = check_residual(nrm2_acc);
+
+    if(use_host_and_acc)
+    {
+        dls.MoveToHost();
+        A.MoveToHost();
+        x.MoveToHost();
+        e.MoveToHost();
+        b.MoveToHost();
+
+        dls.Solve(b, &x);
+
+        // Verify solution
+        x.ScaleAdd(-1.0, e);
+        T nrm2_host = x.Norm();
+        success     = success && check_residual(nrm2_host);
+    }
 
     // Clean up
     dls.Clear();
 
     // Stop rocALUTION platform
     stop_rocalution();
-    disable_accelerator_rocalution(false);
 
     return success;
 }

--- a/clients/tests/test_inversion.cpp
+++ b/clients/tests/test_inversion.cpp
@@ -29,10 +29,10 @@
 
 typedef std::tuple<int, unsigned int, std::string, int> inversion_tuple;
 
-std::vector<int>          inversion_size        = {7, 16, 21};
-std::vector<unsigned int> inversion_format      = {1, 2, 3, 4, 5, 6, 7};
-std::vector<std::string>  inversion_matrix_type = {"Laplacian2D", "PermutedIdentity"};
-std::vector<int>          inversion_use_acc     = {1};
+std::vector<int>          inversion_size             = {7, 16, 21};
+std::vector<unsigned int> inversion_format           = {1, 2, 3, 4, 5, 6, 7};
+std::vector<std::string>  inversion_matrix_type      = {"Laplacian2D", "PermutedIdentity"};
+std::vector<int>          inversion_use_host_and_acc = {0};
 
 // Function to update tests if environment variable is set
 void update_inversion()
@@ -45,6 +45,7 @@ void update_inversion()
         inversion_size.clear();
         inversion_format.clear();
         inversion_matrix_type.clear();
+        inversion_use_host_and_acc.clear();
     }
 
     if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
@@ -52,7 +53,13 @@ void update_inversion()
         inversion_size.push_back(7);
         inversion_format.insert(inversion_format.end(), {1, 2, 3, 4, 5, 6, 7});
         inversion_matrix_type.push_back("Laplacian2D");
-        inversion_use_acc.push_back(0);
+        inversion_use_host_and_acc.push_back(1);
+    }
+    else if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
+                                "ROCALUTION_EMULATION_REGRESSION",
+                                "ROCALUTION_EMULATION_EXTENDED"}))
+    {
+        inversion_use_host_and_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -124,4 +131,4 @@ INSTANTIATE_TEST_CASE_P(inversion,
                         testing::Combine(testing::ValuesIn(inversion_size),
                                          testing::ValuesIn(inversion_format),
                                          testing::ValuesIn(inversion_matrix_type),
-                                         testing::ValuesIn(inversion_use_acc)));
+                                         testing::ValuesIn(inversion_use_host_and_acc)));

--- a/clients/tests/test_lu.cpp
+++ b/clients/tests/test_lu.cpp
@@ -29,10 +29,10 @@
 
 typedef std::tuple<int, unsigned int, std::string, int> lu_tuple;
 
-std::vector<int>          lu_size        = {7, 16, 21};
-std::vector<unsigned int> lu_format      = {1, 2, 3, 4, 5, 6, 7};
-std::vector<std::string>  lu_matrix_type = {"Laplacian2D"};
-std::vector<int>          lu_use_acc     = {1};
+std::vector<int>          lu_size             = {7, 16, 21};
+std::vector<unsigned int> lu_format           = {1, 2, 3, 4, 5, 6, 7};
+std::vector<std::string>  lu_matrix_type      = {"Laplacian2D"};
+std::vector<int>          lu_use_host_and_acc = {0};
 
 // Function to update tests if environment variable is set
 void update_lu()
@@ -44,6 +44,7 @@ void update_lu()
     {
         lu_size.clear();
         lu_format.clear();
+        lu_use_host_and_acc.clear();
 
         lu_size.push_back(16);
         lu_format.push_back(2);
@@ -56,7 +57,13 @@ void update_lu()
 
         lu_size.push_back(7);
         lu_format.insert(lu_format.end(), {1, 2, 3, 4, 5, 6, 7});
-        lu_use_acc.push_back(0);
+        lu_use_host_and_acc.push_back(1);
+    }
+    else if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
+                                "ROCALUTION_EMULATION_REGRESSION",
+                                "ROCALUTION_EMULATION_EXTENDED"}))
+    {
+        lu_use_host_and_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -123,4 +130,4 @@ INSTANTIATE_TEST_CASE_P(lu,
                         testing::Combine(testing::ValuesIn(lu_size),
                                          testing::ValuesIn(lu_format),
                                          testing::ValuesIn(lu_matrix_type),
-                                         testing::ValuesIn(lu_use_acc)));
+                                         testing::ValuesIn(lu_use_host_and_acc)));

--- a/clients/tests/test_qr.cpp
+++ b/clients/tests/test_qr.cpp
@@ -29,10 +29,10 @@
 
 typedef std::tuple<int, unsigned int, std::string, int> qr_tuple;
 
-std::vector<int>          qr_size        = {7, 16, 21};
-std::vector<unsigned int> qr_format      = {1, 2, 3, 4, 5, 6, 7};
-std::vector<std::string>  qr_matrix_type = {"Laplacian2D", "PermutedIdentity"};
-std::vector<int>          qr_use_acc     = {1};
+std::vector<int>          qr_size             = {7, 16, 21};
+std::vector<unsigned int> qr_format           = {1, 2, 3, 4, 5, 6, 7};
+std::vector<std::string>  qr_matrix_type      = {"Laplacian2D", "PermutedIdentity"};
+std::vector<int>          qr_use_host_and_acc = {0};
 
 // Function to update tests if environment variable is set
 void update_qr()
@@ -45,6 +45,7 @@ void update_qr()
         qr_size.clear();
         qr_format.clear();
         qr_matrix_type.clear();
+        qr_use_host_and_acc.clear();
     }
 
     if(is_env_var_set("ROCALUTION_CODE_COVERAGE"))
@@ -52,7 +53,13 @@ void update_qr()
         qr_size.push_back(7);
         qr_format.insert(qr_format.end(), {1, 2, 3, 4, 5, 6, 7});
         qr_matrix_type.push_back("Laplacian2D");
-        qr_use_acc.push_back(0);
+        qr_use_host_and_acc.push_back(1);
+    }
+    else if(is_any_env_var_set({"ROCALUTION_EMULATION_SMOKE",
+                                "ROCALUTION_EMULATION_REGRESSION",
+                                "ROCALUTION_EMULATION_EXTENDED"}))
+    {
+        qr_use_host_and_acc.push_back(0);
     }
 
     if(is_env_var_set("ROCALUTION_EMULATION_SMOKE"))
@@ -122,4 +129,4 @@ INSTANTIATE_TEST_CASE_P(qr,
                         testing::Combine(testing::ValuesIn(qr_size),
                                          testing::ValuesIn(qr_format),
                                          testing::ValuesIn(qr_matrix_type),
-                                         testing::ValuesIn(qr_use_acc)));
+                                         testing::ValuesIn(qr_use_host_and_acc)));


### PR DESCRIPTION
Instead of relying on `disable_accelerator_rocalution` to run the direct solvers on the host or the device, we can (only when `ROCALUTION_CODE_COVERAGE` is set) move the solver to the device, solve, compute the norm error, move the solver back to host, solve, compute the norm of the error, and finally check that both computed norms are sufficiently small.

This has the advantage of covering the `MoveToHostLocalData_` and `MoveToAcceleratorLocalData_` of the solvers.