### PR TITLE
Fix nodiscard warnings

### DIFF
--- a/src/base/hip/backend_hip.cpp
+++ b/src/base/hip/backend_hip.cpp
@@ -60,7 +60,14 @@ namespace rocalution
         _get_backend_descriptor()->ROC_sparse_handle = new rocsparse_handle;
 
         // get last error (if any)
-        hipGetLastError();
+        hipError_t hip_status_t = hipGetLastError();
+
+        if(hip_status_t != hipSuccess)
+        {
+            LOG_INFO("HIP error encountered during rocALUTION HIP backend initialization - falling "
+                     "back to host backend");
+            return false;
+        }
 
         // HIP streams
         assert(_get_backend_descriptor()->HIP_stream_default == NULL);
@@ -81,10 +88,8 @@ namespace rocalution
         _get_backend_descriptor()->HIP_stream_current
             = _get_backend_descriptor()->HIP_stream_default;
 
-        hipError_t hip_status_t;
-        int        num_dev;
-        hipGetDeviceCount(&num_dev);
-        hip_status_t = hipGetLastError();
+        int num_dev;
+        hip_status_t = hipGetDeviceCount(&num_dev);
 
         // if querying for device count fails, fall back to host backend
         if(hip_status_t != hipSuccess)
@@ -115,8 +120,7 @@ namespace rocalution
                     dev = _get_backend_descriptor()->HIP_dev;
                 }
 
-                hipSetDevice(dev);
-                hip_status_t = hipGetLastError();
+                hip_status_t = hipSetDevice(dev);
 
                 if(hip_status_t == hipErrorContextAlreadyInUse)
                 {
@@ -168,7 +172,8 @@ namespace rocalution
         }
 
         struct hipDeviceProp_t dev_prop;
-        hipGetDeviceProperties(&dev_prop, _get_backend_descriptor()->HIP_dev);
+        DISCARD_HIP_ERROR(hipGetDeviceProperties(&dev_prop, _get_backend_descriptor()->HIP_dev));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         if(dev_prop.major < 3)
         {
@@ -270,8 +275,7 @@ namespace rocalution
 
         int num_dev;
 
-        hipGetDeviceCount(&num_dev);
-        hipGetLastError();
+        DISCARD_HIP_ERROR(hipGetDeviceCount(&num_dev));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         if(_get_backend_descriptor()->HIP_dev >= 0)
@@ -281,7 +285,8 @@ namespace rocalution
             LOG_INFO("Selected HIP device: " << backend_descriptor.HIP_dev);
 
             struct hipDeviceProp_t dev_prop;
-            hipGetDeviceProperties(&dev_prop, backend_descriptor.HIP_dev);
+            DISCARD_HIP_ERROR(hipGetDeviceProperties(&dev_prop, backend_descriptor.HIP_dev));
+            CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             // LOG_INFO("Device number: " << backend_descriptor.HIP_dev);
             LOG_INFO("Device name: " << dev_prop.name);                                        // char name[256];
@@ -351,7 +356,8 @@ namespace rocalution
     std::string rocalution_get_arch_hip(void)
     {
         struct hipDeviceProp_t dev_prop;
-        hipGetDeviceProperties(&dev_prop, _get_backend_descriptor()->HIP_dev);
+        DISCARD_HIP_ERROR(hipGetDeviceProperties(&dev_prop, _get_backend_descriptor()->HIP_dev));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
         return dev_prop.gcnArchName;
     }
 
@@ -459,7 +465,7 @@ namespace rocalution
 
     void rocalution_hip_sync(void)
     {
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
         CHECK_HIP_ERROR(__FILE__, __LINE__);
     }
 

--- a/src/base/hip/backend_hip.cpp
+++ b/src/base/hip/backend_hip.cpp
@@ -64,8 +64,10 @@ namespace rocalution
 
         if(hip_status_t != hipSuccess)
         {
-            LOG_INFO("HIP error encountered during rocALUTION HIP backend initialization - falling "
-                     "back to host backend");
+            LOG_VERBOSE_INFO(2,
+                             "*** Warning: HIP error encountered during rocALUTION HIP backend "
+                             "initialization - falling "
+                             "back to host backend");
             return false;
         }
 

--- a/src/base/hip/hip_allocate_free.cpp
+++ b/src/base/hip/hip_allocate_free.cpp
@@ -47,7 +47,7 @@ namespace rocalution
 
             //    *ptr = new DataType[n];
 
-            hipMallocHost((void**)ptr, n * sizeof(DataType));
+            DISCARD_HIP_ERROR(hipMallocHost((void**)ptr, n * sizeof(DataType)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             assert(*ptr != NULL);
@@ -62,7 +62,7 @@ namespace rocalution
         assert(*ptr != NULL);
 
         //  delete[] *ptr;
-        hipFreeHost(*ptr);
+        DISCARD_HIP_ERROR(hipFreeHost(*ptr));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         *ptr = NULL;
@@ -78,7 +78,7 @@ namespace rocalution
         {
             assert(*ptr == NULL);
 
-            hipMalloc((void**)ptr, n * sizeof(DataType));
+            DISCARD_HIP_ERROR(hipMalloc((void**)ptr, n * sizeof(DataType)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             assert(*ptr != NULL);
@@ -115,7 +115,7 @@ namespace rocalution
 
         if(*ptr != NULL)
         {
-            hipFree(*ptr);
+            DISCARD_HIP_ERROR(hipFree(*ptr));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             *ptr = NULL;
@@ -154,11 +154,11 @@ namespace rocalution
 
             if(async == false)
             {
-                hipMemset(ptr, 0, n * sizeof(DataType));
+                DISCARD_HIP_ERROR(hipMemset(ptr, 0, n * sizeof(DataType)));
             }
             else
             {
-                hipMemsetAsync(ptr, 0, n * sizeof(DataType), stream);
+                DISCARD_HIP_ERROR(hipMemsetAsync(ptr, 0, n * sizeof(DataType), stream));
             }
 
             CHECK_HIP_ERROR(__FILE__, __LINE__);
@@ -229,11 +229,12 @@ namespace rocalution
 
             if(async == false)
             {
-                hipMemcpy(dst, src, sizeof(DataType) * n, hipMemcpyDeviceToHost);
+                DISCARD_HIP_ERROR(hipMemcpy(dst, src, sizeof(DataType) * n, hipMemcpyDeviceToHost));
             }
             else
             {
-                hipMemcpyAsync(dst, src, sizeof(DataType) * n, hipMemcpyDeviceToHost, stream);
+                DISCARD_HIP_ERROR(
+                    hipMemcpyAsync(dst, src, sizeof(DataType) * n, hipMemcpyDeviceToHost, stream));
             }
 
             CHECK_HIP_ERROR(__FILE__, __LINE__);
@@ -252,11 +253,12 @@ namespace rocalution
 
             if(async == false)
             {
-                hipMemcpy(dst, src, sizeof(DataType) * n, hipMemcpyHostToDevice);
+                DISCARD_HIP_ERROR(hipMemcpy(dst, src, sizeof(DataType) * n, hipMemcpyHostToDevice));
             }
             else
             {
-                hipMemcpyAsync(dst, src, sizeof(DataType) * n, hipMemcpyHostToDevice, stream);
+                DISCARD_HIP_ERROR(
+                    hipMemcpyAsync(dst, src, sizeof(DataType) * n, hipMemcpyHostToDevice, stream));
             }
 
             CHECK_HIP_ERROR(__FILE__, __LINE__);
@@ -275,11 +277,13 @@ namespace rocalution
 
             if(async == false)
             {
-                hipMemcpy(dst, src, sizeof(DataType) * n, hipMemcpyDeviceToDevice);
+                DISCARD_HIP_ERROR(
+                    hipMemcpy(dst, src, sizeof(DataType) * n, hipMemcpyDeviceToDevice));
             }
             else
             {
-                hipMemcpyAsync(dst, src, sizeof(DataType) * n, hipMemcpyDeviceToDevice, stream);
+                DISCARD_HIP_ERROR(hipMemcpyAsync(
+                    dst, src, sizeof(DataType) * n, hipMemcpyDeviceToDevice, stream));
             }
 
             CHECK_HIP_ERROR(__FILE__, __LINE__);

--- a/src/base/hip/hip_conversion.cpp
+++ b/src/base/hip/hip_conversion.cpp
@@ -75,7 +75,8 @@ namespace rocalution
         CHECK_ROCSPARSE_ERROR(status, __FILE__, __LINE__);
 
         // Sync memcopy
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         return true;
     }
@@ -113,7 +114,8 @@ namespace rocalution
         CHECK_ROCSPARSE_ERROR(status, __FILE__, __LINE__);
 
         // Sync memcopy
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         return true;
     }
@@ -455,28 +457,28 @@ namespace rocalution
         char*  rocprim_buffer = NULL;
 
         // Get reduction buffer size
-        rocprim::reduce(rocprim_buffer,
-                        rocprim_size,
-                        diag_idx,
-                        d_num_diag,
-                        0,
-                        nrow + ncol,
-                        rocprim::plus<IndexType>(),
-                        stream);
+        DISCARD_HIP_ERROR(rocprim::reduce(rocprim_buffer,
+                                          rocprim_size,
+                                          diag_idx,
+                                          d_num_diag,
+                                          0,
+                                          nrow + ncol,
+                                          rocprim::plus<IndexType>(),
+                                          stream));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Allocate rocprim buffer
         allocate_hip(rocprim_size, &rocprim_buffer);
 
         // Do reduction
-        rocprim::reduce(rocprim_buffer,
-                        rocprim_size,
-                        diag_idx,
-                        d_num_diag,
-                        0,
-                        nrow + ncol,
-                        rocprim::plus<IndexType>(),
-                        stream);
+        DISCARD_HIP_ERROR(rocprim::reduce(rocprim_buffer,
+                                          rocprim_size,
+                                          diag_idx,
+                                          d_num_diag,
+                                          0,
+                                          nrow + ncol,
+                                          rocprim::plus<IndexType>(),
+                                          stream));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Clear rocprim buffer
@@ -513,14 +515,14 @@ namespace rocalution
         rocprim_size   = 0;
 
         // Obtain rocprim buffer size
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                diag_idx,
-                                work,
-                                0,
-                                nrow + ncol,
-                                rocprim::plus<IndexType>(),
-                                stream);
+        DISCARD_HIP_ERROR(rocprim::exclusive_scan(rocprim_buffer,
+                                                  rocprim_size,
+                                                  diag_idx,
+                                                  work,
+                                                  0,
+                                                  nrow + ncol,
+                                                  rocprim::plus<IndexType>(),
+                                                  stream));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Allocate rocprim buffer
@@ -528,14 +530,14 @@ namespace rocalution
         allocate_hip(rocprim_size, &rocprim_buffer);
 
         // Do inclusive sum
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                diag_idx,
-                                work,
-                                0,
-                                nrow + ncol,
-                                rocprim::plus<IndexType>(),
-                                stream);
+        DISCARD_HIP_ERROR(rocprim::exclusive_scan(rocprim_buffer,
+                                                  rocprim_size,
+                                                  diag_idx,
+                                                  work,
+                                                  0,
+                                                  nrow + ncol,
+                                                  rocprim::plus<IndexType>(),
+                                                  stream));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Clear rocprim buffer
@@ -620,28 +622,28 @@ namespace rocalution
             char*  rocprim_buffer = NULL;
 
             // Obtain rocprim buffer size
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    coo_row_nnz,
-                                    coo_row_nnz,
-                                    0,
-                                    nrow + 1,
-                                    rocprim::plus<PointerType>(),
-                                    stream);
+            DISCARD_HIP_ERROR(rocprim::exclusive_scan(rocprim_buffer,
+                                                      rocprim_size,
+                                                      coo_row_nnz,
+                                                      coo_row_nnz,
+                                                      0,
+                                                      nrow + 1,
+                                                      rocprim::plus<PointerType>(),
+                                                      stream));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             // Allocate rocprim buffer
             allocate_hip(rocprim_size, &rocprim_buffer);
 
             // Do exclusive sum
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    coo_row_nnz,
-                                    coo_row_nnz,
-                                    0,
-                                    nrow + 1,
-                                    rocprim::plus<PointerType>(),
-                                    stream);
+            DISCARD_HIP_ERROR(rocprim::exclusive_scan(rocprim_buffer,
+                                                      rocprim_size,
+                                                      coo_row_nnz,
+                                                      coo_row_nnz,
+                                                      0,
+                                                      nrow + 1,
+                                                      rocprim::plus<PointerType>(),
+                                                      stream));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             // Clear rocprim buffer
@@ -758,7 +760,8 @@ namespace rocalution
         }
 
         // Sync memcopy
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         return true;
     }
@@ -880,7 +883,8 @@ namespace rocalution
         }
 
         // Sync memcopy
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         *nnz_csr = nnz_total;
 

--- a/src/base/hip/hip_matrix_bcsr.cpp
+++ b/src/base/hip/hip_matrix_bcsr.cpp
@@ -185,7 +185,8 @@ namespace rocalution
 
         this->Clear();
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         this->nrow_ = nrowb * blockdim;
         this->ncol_ = ncolb * blockdim;
@@ -212,7 +213,8 @@ namespace rocalution
         assert(this->nnz_ >= 0);
         assert(this->mat_.blockdim > 1);
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         *row_offset = this->mat_.row_offset;
         *col        = this->mat_.col;

--- a/src/base/hip/hip_matrix_coo.cpp
+++ b/src/base/hip/hip_matrix_coo.cpp
@@ -144,7 +144,8 @@ namespace rocalution
         this->ncol_ = ncol;
         this->nnz_  = nnz;
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         this->mat_.row = *row;
         this->mat_.col = *col;
@@ -158,7 +159,8 @@ namespace rocalution
         assert(this->ncol_ >= 0);
         assert(this->nnz_ >= 0);
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // see free_host function for details
         *row = this->mat_.row;

--- a/src/base/hip/hip_matrix_csr.cpp
+++ b/src/base/hip/hip_matrix_csr.cpp
@@ -193,7 +193,8 @@ namespace rocalution
         this->ncol_ = ncol;
         this->nnz_  = nnz;
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         this->mat_.row_offset = *row_offset;
         this->mat_.col        = *col;
@@ -211,7 +212,8 @@ namespace rocalution
         assert(this->ncol_ >= 0);
         assert(this->nnz_ >= 0);
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // see free_host function for details
         *row_offset = this->mat_.row_offset;
@@ -995,26 +997,28 @@ namespace rocalution
             // Determine maximum
             PtrType* d_max = NULL;
             allocate_hip(1, &d_max);
-            rocprim::reduce(buffer,
-                            size,
-                            d_nnzPerm,
-                            d_max,
-                            0,
-                            this->nrow_,
-                            rocprim::maximum<PtrType>(),
-                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::reduce(buffer,
+                                size,
+                                d_nnzPerm,
+                                d_max,
+                                0,
+                                this->nrow_,
+                                rocprim::maximum<PtrType>(),
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             allocate_hip(size, &buffer);
 
-            rocprim::reduce(buffer,
-                            size,
-                            d_nnzPerm,
-                            d_max,
-                            0,
-                            this->nrow_,
-                            rocprim::maximum<PtrType>(),
-                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::reduce(buffer,
+                                size,
+                                d_nnzPerm,
+                                d_max,
+                                0,
+                                this->nrow_,
+                                rocprim::maximum<PtrType>(),
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             free_hip(&buffer);
@@ -1025,24 +1029,26 @@ namespace rocalution
             free_hip(&d_max);
 
             // Inclusive sum
-            rocprim::inclusive_scan(buffer,
-                                    size,
-                                    d_nnzPerm + 1,
-                                    d_nnzPerm + 1,
-                                    this->nrow_,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::inclusive_scan(buffer,
+                                        size,
+                                        d_nnzPerm + 1,
+                                        d_nnzPerm + 1,
+                                        this->nrow_,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             allocate_hip(size, &buffer);
 
-            rocprim::inclusive_scan(buffer,
-                                    size,
-                                    d_nnzPerm + 1,
-                                    d_nnzPerm + 1,
-                                    this->nrow_,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::inclusive_scan(buffer,
+                                        size,
+                                        d_nnzPerm + 1,
+                                        d_nnzPerm + 1,
+                                        this->nrow_,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             free_hip(&buffer);
@@ -3433,26 +3439,28 @@ namespace rocalution
         size_t rocprim_size;
         char*  rocprim_buffer = NULL;
 
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                row_nnz,
-                                row_nnz,
-                                0,
-                                row_size + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    row_nnz,
+                                    row_nnz,
+                                    0,
+                                    row_size + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                row_nnz,
-                                row_nnz,
-                                0,
-                                row_size + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    row_nnz,
+                                    row_nnz,
+                                    0,
+                                    row_size + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -3527,26 +3535,28 @@ namespace rocalution
         size_t rocprim_size;
         char*  rocprim_buffer = NULL;
 
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                cast_L->mat_.row_offset,
-                                cast_L->mat_.row_offset,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    cast_L->mat_.row_offset,
+                                    cast_L->mat_.row_offset,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                cast_L->mat_.row_offset,
-                                cast_L->mat_.row_offset,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    cast_L->mat_.row_offset,
+                                    cast_L->mat_.row_offset,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -3615,26 +3625,28 @@ namespace rocalution
         size_t rocprim_size;
         char*  rocprim_buffer = NULL;
 
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                cast_L->mat_.row_offset,
-                                cast_L->mat_.row_offset,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    cast_L->mat_.row_offset,
+                                    cast_L->mat_.row_offset,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                cast_L->mat_.row_offset,
-                                cast_L->mat_.row_offset,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    cast_L->mat_.row_offset,
+                                    cast_L->mat_.row_offset,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -3703,26 +3715,28 @@ namespace rocalution
         size_t rocprim_size;
         char*  rocprim_buffer = NULL;
 
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                cast_U->mat_.row_offset,
-                                cast_U->mat_.row_offset,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    cast_U->mat_.row_offset,
+                                    cast_U->mat_.row_offset,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                cast_U->mat_.row_offset,
-                                cast_U->mat_.row_offset,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    cast_U->mat_.row_offset,
+                                    cast_U->mat_.row_offset,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -3791,26 +3805,28 @@ namespace rocalution
         size_t rocprim_size;
         char*  rocprim_buffer = NULL;
 
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                cast_U->mat_.row_offset,
-                                cast_U->mat_.row_offset,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    cast_U->mat_.row_offset,
+                                    cast_U->mat_.row_offset,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                cast_U->mat_.row_offset,
-                                cast_U->mat_.row_offset,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    cast_U->mat_.row_offset,
+                                    cast_U->mat_.row_offset,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -4533,26 +4549,28 @@ namespace rocalution
             size_t rocprim_size;
             char*  rocprim_buffer = NULL;
 
-            rocprim::exclusive_scan(NULL,
-                                    rocprim_size,
-                                    row_offset,
-                                    mat_row_offset,
-                                    0,
-                                    nrow + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(NULL,
+                                        rocprim_size,
+                                        row_offset,
+                                        mat_row_offset,
+                                        0,
+                                        nrow + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             allocate_hip(rocprim_size, &rocprim_buffer);
 
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    row_offset,
-                                    mat_row_offset,
-                                    0,
-                                    nrow + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(rocprim_buffer,
+                                        rocprim_size,
+                                        row_offset,
+                                        mat_row_offset,
+                                        0,
+                                        nrow + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             free_hip(&rocprim_buffer);
@@ -4694,26 +4712,28 @@ namespace rocalution
             size_t rocprim_size;
             char*  rocprim_buffer = NULL;
 
-            rocprim::exclusive_scan(NULL,
-                                    rocprim_size,
-                                    row_offset,
-                                    row_offset,
-                                    0,
-                                    this->nrow_ + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(NULL,
+                                        rocprim_size,
+                                        row_offset,
+                                        row_offset,
+                                        0,
+                                        this->nrow_ + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             allocate_hip(rocprim_size, &rocprim_buffer);
 
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    row_offset,
-                                    row_offset,
-                                    0,
-                                    this->nrow_,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(rocprim_buffer,
+                                        rocprim_size,
+                                        row_offset,
+                                        row_offset,
+                                        0,
+                                        this->nrow_,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             free_hip(&rocprim_buffer);
@@ -5002,7 +5022,7 @@ namespace rocalution
                              HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        hipMalloc(&buffer, size);
+        DISCARD_HIP_ERROR(hipMalloc(&buffer, size));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         rocprimTexclusivesum(buffer,
@@ -5013,7 +5033,7 @@ namespace rocalution
                              HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        hipFree(buffer);
+        DISCARD_HIP_ERROR(hipFree(buffer));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Fill
@@ -5217,7 +5237,9 @@ namespace rocalution
         int iter = 0;
         while(!hdone)
         {
-            hipMemcpy(max_tuples, tuples, sizeof(mis_tuple) * this->nrow_, hipMemcpyDeviceToDevice);
+            DISCARD_HIP_ERROR(hipMemcpy(
+                max_tuples, tuples, sizeof(mis_tuple) * this->nrow_, hipMemcpyDeviceToDevice));
+            CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             if(avg_nnz_per_row <= 8)
             {
@@ -5351,33 +5373,37 @@ namespace rocalution
         size_t rocprim_size;
         char*  rocprim_buffer = NULL;
 
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                cast_agg->vec_,
-                                cast_agg->vec_,
-                                0,
-                                this->nrow_,
-                                rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    cast_agg->vec_,
+                                    cast_agg->vec_,
+                                    0,
+                                    this->nrow_,
+                                    rocprim::plus<int>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                cast_agg->vec_,
-                                cast_agg->vec_,
-                                0,
-                                this->nrow_,
-                                rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    cast_agg->vec_,
+                                    cast_agg->vec_,
+                                    0,
+                                    this->nrow_,
+                                    rocprim::plus<int>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
 
         for(int k = 0; k < 2; k++)
         {
-            hipMemcpy(max_tuples, tuples, sizeof(mis_tuple) * this->nrow_, hipMemcpyDeviceToDevice);
+            DISCARD_HIP_ERROR(hipMemcpy(
+                max_tuples, tuples, sizeof(mis_tuple) * this->nrow_, hipMemcpyDeviceToDevice));
+            CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             kernel_csr_amg_update_aggregates<<<
                 GridSize,
@@ -5433,26 +5459,28 @@ namespace rocalution
         char*  rocprim_buffer = NULL;
 
         // Obtain maximum entry in aggregation array
-        rocprim::reduce(NULL,
-                        rocprim_size,
-                        cast_agg->vec_,
-                        prolong_row_offset,
-                        -2,
-                        cast_agg->size_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(NULL,
+                            rocprim_size,
+                            cast_agg->vec_,
+                            prolong_row_offset,
+                            -2,
+                            cast_agg->size_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::reduce(rocprim_buffer,
-                        rocprim_size,
-                        cast_agg->vec_,
-                        prolong_row_offset,
-                        -2,
-                        cast_agg->size_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(rocprim_buffer,
+                            rocprim_size,
+                            cast_agg->vec_,
+                            prolong_row_offset,
+                            -2,
+                            cast_agg->size_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -5472,26 +5500,28 @@ namespace rocalution
             this->nrow_, this->mat_.row_offset, prolong_row_offset + 1);
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        rocprim::reduce(NULL,
-                        rocprim_size,
-                        prolong_row_offset + 1,
-                        prolong_row_offset,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(NULL,
+                            rocprim_size,
+                            prolong_row_offset + 1,
+                            prolong_row_offset,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::reduce(rocprim_buffer,
-                        rocprim_size,
-                        prolong_row_offset + 1,
-                        prolong_row_offset,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(rocprim_buffer,
+                            rocprim_size,
+                            prolong_row_offset + 1,
+                            prolong_row_offset,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -5679,26 +5709,28 @@ namespace rocalution
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Obtain maximum row nnz to determine correct map size
-        rocprim::reduce(NULL,
-                        rocprim_size,
-                        prolong_row_offset,
-                        prolong_row_offset + this->nrow_,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(NULL,
+                            rocprim_size,
+                            prolong_row_offset,
+                            prolong_row_offset + this->nrow_,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::reduce(rocprim_buffer,
-                        rocprim_size,
-                        prolong_row_offset,
-                        prolong_row_offset + this->nrow_,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(rocprim_buffer,
+                            rocprim_size,
+                            prolong_row_offset,
+                            prolong_row_offset + this->nrow_,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -5707,26 +5739,28 @@ namespace rocalution
         copy_d2h(1, prolong_row_offset + this->nrow_, &max_row_nnz);
 
         // Perform exclusive scan on csr row pointer array
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                prolong_row_offset,
-                                prolong_row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    prolong_row_offset,
+                                    prolong_row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<int>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                prolong_row_offset,
-                                prolong_row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    prolong_row_offset,
+                                    prolong_row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<int>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -5981,22 +6015,24 @@ namespace rocalution
         // Perform inclusive scan on csr row pointer array
         size_t rocprim_size;
         char*  rocprim_buffer = NULL;
-        rocprim::inclusive_scan(nullptr,
-                                rocprim_size,
-                                prolong_row_offset,
-                                prolong_row_offset,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::inclusive_scan(nullptr,
+                                    rocprim_size,
+                                    prolong_row_offset,
+                                    prolong_row_offset,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
         allocate_hip(rocprim_size, &rocprim_buffer);
-        rocprim::inclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                prolong_row_offset,
-                                prolong_row_offset,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::inclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    prolong_row_offset,
+                                    prolong_row_offset,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
         free_hip(&rocprim_buffer);
         PtrType prolong_nnz = 0;
@@ -7178,64 +7214,64 @@ namespace rocalution
         char*  rocprim_buffer = NULL;
 
         size_t size;
-        rocprim::reduce(NULL,
+        DISCARD_HIP_ERROR(rocprim::reduce(NULL,
                         size,
                         cast_agg->vec_,
                         prolong_row_offset,
                         -2,
                         cast_agg->size_,
                         rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         rocprim_size = std::max(rocprim_size, size);
 
-        rocprim::reduce(NULL,
+        DISCARD_HIP_ERROR(rocprim::reduce(NULL,
                         size,
                         prolong_row_offset + 1,
                         prolong_row_offset,
                         0,
                         this->nrow_,
                         rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         rocprim_size = std::max(rocprim_size, size);
 
-        rocprim::reduce(NULL,
+        DISCARD_HIP_ERROR(rocprim::reduce(NULL,
                         size,
                         prolong_row_offset,
                         prolong_row_offset + this->nrow_,
                         0,
                         this->nrow_,
                         rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         rocprim_size = std::max(rocprim_size, size);
 
-        rocprim::exclusive_scan(NULL,
+        DISCARD_HIP_ERROR(rocprim::exclusive_scan(NULL,
                                 size,
                                 prolong_row_offset,
                                 prolong_row_offset,
                                 0,
                                 this->nrow_ + 1,
                                 rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         rocprim_size = std::max(rocprim_size, size);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::reduce(rocprim_buffer,
+        DISCARD_HIP_ERROR(rocprim::reduce(rocprim_buffer,
                         rocprim_size,
                         cast_agg->vec_,
                         prolong_row_offset,
                         -2,
                         cast_agg->size_,
                         rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Obtain sizes of P
@@ -7251,14 +7287,14 @@ namespace rocalution
             this->nrow_, this->mat_.row_offset, prolong_row_offset + 1);
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        rocprim::reduce(rocprim_buffer,
+        DISCARD_HIP_ERROR(rocprim::reduce(rocprim_buffer,
                         rocprim_size,
                         prolong_row_offset + 1,
                         prolong_row_offset,
                         0,
                         this->nrow_,
                         rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         int max_row_nnz;
@@ -7379,26 +7415,26 @@ namespace rocalution
         }
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        rocprim::reduce(rocprim_buffer,
+        DISCARD_HIP_ERROR(rocprim::reduce(rocprim_buffer,
                         rocprim_size,
                         prolong_row_offset,
                         prolong_row_offset + this->nrow_,
                         0,
                         this->nrow_,
                         rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         copy_d2h(1, prolong_row_offset + this->nrow_, &max_row_nnz);
 
-        rocprim::exclusive_scan(rocprim_buffer,
+        DISCARD_HIP_ERROR(rocprim::exclusive_scan(rocprim_buffer,
                                 rocprim_size,
                                 prolong_row_offset,
                                 prolong_row_offset,
                                 0,
                                 this->nrow_ + 1,
                                 rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         PtrType prolong_nnz;
@@ -7614,24 +7650,26 @@ namespace rocalution
         // Perform inclusive scan on csr row pointer array
         size_t rocprim_size;
         char*  rocprim_buffer = NULL;
-        rocprim::inclusive_scan(nullptr,
-                                rocprim_size,
-                                prolong_row_offset,
-                                prolong_row_offset,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::inclusive_scan(nullptr,
+                                    rocprim_size,
+                                    prolong_row_offset,
+                                    prolong_row_offset,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::inclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                prolong_row_offset,
-                                prolong_row_offset,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::inclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    prolong_row_offset,
+                                    prolong_row_offset,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -7750,25 +7788,28 @@ namespace rocalution
         size_t rocprim_size   = 0;
         char*  rocprim_buffer = NULL;
 
-        rocprim::reduce(NULL,
-                        rocprim_size,
-                        cast_pi->mat_.row_offset + 1,
-                        cast_pi->mat_.row_offset,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(NULL,
+                            rocprim_size,
+                            cast_pi->mat_.row_offset + 1,
+                            cast_pi->mat_.row_offset,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::reduce(rocprim_buffer,
-                        rocprim_size,
-                        cast_pi->mat_.row_offset + 1,
-                        cast_pi->mat_.row_offset,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(rocprim_buffer,
+                            rocprim_size,
+                            cast_pi->mat_.row_offset + 1,
+                            cast_pi->mat_.row_offset,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         if(global == true)
@@ -7781,14 +7822,15 @@ namespace rocalution
                 this->nrow_, cast_gst->mat_.row_offset, cast_pg->mat_.row_offset + 1);
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            rocprim::reduce(rocprim_buffer,
-                            rocprim_size,
-                            cast_pg->mat_.row_offset + 1,
-                            cast_pg->mat_.row_offset,
-                            0,
-                            this->nrow_,
-                            rocprim::maximum<int>(),
-                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::reduce(rocprim_buffer,
+                                rocprim_size,
+                                cast_pg->mat_.row_offset + 1,
+                                cast_pg->mat_.row_offset,
+                                0,
+                                this->nrow_,
+                                rocprim::maximum<int>(),
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
         }
 
@@ -8240,38 +8282,41 @@ namespace rocalution
         char*  rocprim_buffer = NULL;
 
         // Determine maximum number of non-zeros per row of internal prolongation matrix
-        rocprim::reduce(NULL,
-                        rocprim_size,
-                        cast_pi->mat_.row_offset,
-                        cast_pi->mat_.row_offset + this->nrow_,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(NULL,
+                            rocprim_size,
+                            cast_pi->mat_.row_offset,
+                            cast_pi->mat_.row_offset + this->nrow_,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::reduce(rocprim_buffer,
-                        rocprim_size,
-                        cast_pi->mat_.row_offset,
-                        cast_pi->mat_.row_offset + this->nrow_,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(rocprim_buffer,
+                            rocprim_size,
+                            cast_pi->mat_.row_offset,
+                            cast_pi->mat_.row_offset + this->nrow_,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         if(global)
         {
-            rocprim::reduce(rocprim_buffer,
-                            rocprim_size,
-                            cast_pg->mat_.row_offset,
-                            cast_pg->mat_.row_offset + this->nrow_,
-                            0,
-                            this->nrow_,
-                            rocprim::maximum<int>(),
-                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::reduce(rocprim_buffer,
+                                rocprim_size,
+                                cast_pg->mat_.row_offset,
+                                cast_pg->mat_.row_offset + this->nrow_,
+                                0,
+                                this->nrow_,
+                                rocprim::maximum<int>(),
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
         }
 
@@ -8287,26 +8332,28 @@ namespace rocalution
         }
 
         // Perform exclusive scan on internal prolongation row offsets
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                cast_pi->mat_.row_offset,
-                                cast_pi->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    cast_pi->mat_.row_offset,
+                                    cast_pi->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                cast_pi->mat_.row_offset,
-                                cast_pi->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    cast_pi->mat_.row_offset,
+                                    cast_pi->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -8334,26 +8381,28 @@ namespace rocalution
             assert(cast_glo != NULL);
 
             // Perform exclusive scan on ghost prolongation row offsets
-            rocprim::exclusive_scan(NULL,
-                                    rocprim_size,
-                                    cast_pg->mat_.row_offset,
-                                    cast_pg->mat_.row_offset,
-                                    0,
-                                    this->nrow_ + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(NULL,
+                                        rocprim_size,
+                                        cast_pg->mat_.row_offset,
+                                        cast_pg->mat_.row_offset,
+                                        0,
+                                        this->nrow_ + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             allocate_hip(rocprim_size, &rocprim_buffer);
 
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    cast_pg->mat_.row_offset,
-                                    cast_pg->mat_.row_offset,
-                                    0,
-                                    this->nrow_ + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(rocprim_buffer,
+                                        rocprim_size,
+                                        cast_pg->mat_.row_offset,
+                                        cast_pg->mat_.row_offset,
+                                        0,
+                                        this->nrow_ + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             free_hip(&rocprim_buffer);
@@ -8983,26 +9032,28 @@ namespace rocalution
         char*  rocprim_buffer = NULL;
 
         // Perform exclusive scan on internal prolongation row offsets
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                cast_pi->mat_.row_offset,
-                                cast_pi->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    cast_pi->mat_.row_offset,
+                                    cast_pi->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                cast_pi->mat_.row_offset,
-                                cast_pi->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    cast_pi->mat_.row_offset,
+                                    cast_pi->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -9030,26 +9081,28 @@ namespace rocalution
             assert(cast_glo != NULL);
 
             // Perform exclusive scan on ghost prolongation row offsets
-            rocprim::exclusive_scan(NULL,
-                                    rocprim_size,
-                                    cast_pg->mat_.row_offset,
-                                    cast_pg->mat_.row_offset,
-                                    0,
-                                    this->nrow_ + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(NULL,
+                                        rocprim_size,
+                                        cast_pg->mat_.row_offset,
+                                        cast_pg->mat_.row_offset,
+                                        0,
+                                        this->nrow_ + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             allocate_hip(rocprim_size, &rocprim_buffer);
 
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    cast_pg->mat_.row_offset,
-                                    cast_pg->mat_.row_offset,
-                                    0,
-                                    this->nrow_ + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(rocprim_buffer,
+                                        rocprim_size,
+                                        cast_pg->mat_.row_offset,
+                                        cast_pg->mat_.row_offset,
+                                        0,
+                                        this->nrow_ + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             free_hip(&rocprim_buffer);
@@ -9177,24 +9230,34 @@ namespace rocalution
         size_t rocprim_size;
         void*  rocprim_buffer = NULL;
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                workspace,
-                                workspace,
-                                0,
-                                ext_nnz + 1,
-                                rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
-        hipMalloc(&rocprim_buffer, rocprim_size);
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                workspace,
-                                workspace,
-                                0,
-                                ext_nnz + 1,
-                                rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
-        hipFree(rocprim_buffer);
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    workspace,
+                                    workspace,
+                                    0,
+                                    ext_nnz + 1,
+                                    rocprim::plus<int>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
+
+        DISCARD_HIP_ERROR(hipMalloc(&rocprim_buffer, rocprim_size));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
+
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    workspace,
+                                    workspace,
+                                    0,
+                                    ext_nnz + 1,
+                                    rocprim::plus<int>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
+
+        DISCARD_HIP_ERROR(hipFree(rocprim_buffer));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
+
         rocprim_buffer = NULL;
 
         // Fill
@@ -9237,30 +9300,32 @@ namespace rocalution
         int* d_nruns = NULL;
         allocate_hip(1, &d_nruns);
 
-        rocprim::run_length_encode(rocprim_buffer,
-                                   rocprim_size,
-                                   gcol_sorted.vec_,
-                                   total_nnz,
-                                   cast_map->vec_,
-                                   cast_cmb->vec_,
-                                   d_nruns,
-                                   HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::run_length_encode(rocprim_buffer,
+                                       rocprim_size,
+                                       gcol_sorted.vec_,
+                                       total_nnz,
+                                       cast_map->vec_,
+                                       cast_cmb->vec_,
+                                       d_nruns,
+                                       HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        hipMalloc(&rocprim_buffer, rocprim_size);
+        DISCARD_HIP_ERROR(hipMalloc(&rocprim_buffer, rocprim_size));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        rocprim::run_length_encode(rocprim_buffer,
-                                   rocprim_size,
-                                   gcol_sorted.vec_,
-                                   total_nnz,
-                                   cast_map->vec_,
-                                   cast_cmb->vec_,
-                                   d_nruns,
-                                   HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::run_length_encode(rocprim_buffer,
+                                       rocprim_size,
+                                       gcol_sorted.vec_,
+                                       total_nnz,
+                                       cast_map->vec_,
+                                       cast_cmb->vec_,
+                                       d_nruns,
+                                       HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        hipFree(rocprim_buffer);
+        DISCARD_HIP_ERROR(hipFree(rocprim_buffer));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         rocprim_buffer = NULL;
@@ -9281,30 +9346,32 @@ namespace rocalution
         // Prefix sum to get entry points to duplicates
         if(nruns > 0)
         {
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    cast_cmb->vec_,
-                                    workspace2,
-                                    0,
-                                    nruns + 1,
-                                    rocprim::plus<int>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(rocprim_buffer,
+                                        rocprim_size,
+                                        cast_cmb->vec_,
+                                        workspace2,
+                                        0,
+                                        nruns + 1,
+                                        rocprim::plus<int>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            hipMalloc(&rocprim_buffer, rocprim_size);
+            DISCARD_HIP_ERROR(hipMalloc(&rocprim_buffer, rocprim_size));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    cast_cmb->vec_,
-                                    workspace2,
-                                    0,
-                                    nruns + 1,
-                                    rocprim::plus<int>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(rocprim_buffer,
+                                        rocprim_size,
+                                        cast_cmb->vec_,
+                                        workspace2,
+                                        0,
+                                        nruns + 1,
+                                        rocprim::plus<int>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            hipFree(rocprim_buffer);
+            DISCARD_HIP_ERROR(hipFree(rocprim_buffer));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
         }
 
@@ -9377,32 +9444,37 @@ namespace rocalution
         size_t size;
         void*  buffer = NULL;
 
-        rocprimTexclusivesum(buffer,
-                             size,
-                             int_csr_row_ptr,
-                             int_csr_row_ptr,
-                             this->nrow_ + 1,
-                             HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprimTexclusivesum(buffer,
+                                 size,
+                                 int_csr_row_ptr,
+                                 int_csr_row_ptr,
+                                 this->nrow_ + 1,
+                                 HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        hipMalloc(&buffer, size);
+        DISCARD_HIP_ERROR(hipMalloc(&buffer, size));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        rocprimTexclusivesum(buffer,
-                             size,
-                             int_csr_row_ptr,
-                             int_csr_row_ptr,
-                             this->nrow_ + 1,
-                             HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
-        rocprimTexclusivesum(buffer,
-                             size,
-                             gst_csr_row_ptr,
-                             gst_csr_row_ptr,
-                             this->nrow_ + 1,
-                             HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprimTexclusivesum(buffer,
+                                 size,
+                                 int_csr_row_ptr,
+                                 int_csr_row_ptr,
+                                 this->nrow_ + 1,
+                                 HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        hipFree(buffer);
+        DISCARD_HIP_ERROR(
+            rocprimTexclusivesum(buffer,
+                                 size,
+                                 gst_csr_row_ptr,
+                                 gst_csr_row_ptr,
+                                 this->nrow_ + 1,
+                                 HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
+
+        DISCARD_HIP_ERROR(hipFree(buffer));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         PtrType int_nnz;
@@ -9575,26 +9647,28 @@ namespace rocalution
         size_t rocprim_size;
         char*  rocprim_buffer = NULL;
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                this->mat_.row_offset,
-                                this->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    this->mat_.row_offset,
+                                    this->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<int>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                this->mat_.row_offset,
-                                this->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<int>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    this->mat_.row_offset,
+                                    this->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<int>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -9694,31 +9768,42 @@ namespace rocalution
         size_t rocprim_size;
         void*  rocprim_buffer = NULL;
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                int_csr_row_ptr,
-                                int_csr_row_ptr,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
-        hipMalloc(&rocprim_buffer, rocprim_size);
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                int_csr_row_ptr,
-                                int_csr_row_ptr,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>());
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                gst_csr_row_ptr,
-                                gst_csr_row_ptr,
-                                0,
-                                nrow + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
-        hipFree(rocprim_buffer);
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    int_csr_row_ptr,
+                                    int_csr_row_ptr,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
+
+        DISCARD_HIP_ERROR(hipMalloc(&rocprim_buffer, rocprim_size));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
+
+        DISCARD_HIP_ERROR(rocprim::exclusive_scan(rocprim_buffer,
+                                                  rocprim_size,
+                                                  int_csr_row_ptr,
+                                                  int_csr_row_ptr,
+                                                  0,
+                                                  nrow + 1,
+                                                  rocprim::plus<PtrType>()));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
+
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    gst_csr_row_ptr,
+                                    gst_csr_row_ptr,
+                                    0,
+                                    nrow + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
+
+        DISCARD_HIP_ERROR(hipFree(rocprim_buffer));
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         PtrType int_nnz;
         PtrType gst_nnz;
@@ -9830,30 +9915,32 @@ namespace rocalution
             size_t rocprim_size;
             void*  rocprim_buffer;
 
-            rocprim::reduce(NULL,
-                            rocprim_size,
-                            csr_row_ptr,
-                            csr_row_ptr + nrow,
-                            0,
-                            nrow,
-                            rocprim::maximum<int>(),
-                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::reduce(NULL,
+                                rocprim_size,
+                                csr_row_ptr,
+                                csr_row_ptr + nrow,
+                                0,
+                                nrow,
+                                rocprim::maximum<int>(),
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            hipMalloc(&rocprim_buffer, rocprim_size);
+            DISCARD_HIP_ERROR(hipMalloc(&rocprim_buffer, rocprim_size));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            rocprim::reduce(rocprim_buffer,
-                            rocprim_size,
-                            csr_row_ptr,
-                            csr_row_ptr + nrow,
-                            0,
-                            nrow,
-                            rocprim::maximum<int>(),
-                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::reduce(rocprim_buffer,
+                                rocprim_size,
+                                csr_row_ptr,
+                                csr_row_ptr + nrow,
+                                0,
+                                nrow,
+                                rocprim::maximum<int>(),
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            hipFree(rocprim_buffer);
+            DISCARD_HIP_ERROR(hipFree(rocprim_buffer));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             // Get maximum row nnz on host
@@ -10201,60 +10288,64 @@ namespace rocalution
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             // Obtain actual max nnz per row
-            rocprim::reduce(NULL,
-                            rocprim_size,
-                            csr_row_ptr,
-                            csr_row_ptr + nrow,
-                            0,
-                            nrow,
-                            rocprim::maximum<int>(),
-                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::reduce(NULL,
+                                rocprim_size,
+                                csr_row_ptr,
+                                csr_row_ptr + nrow,
+                                0,
+                                nrow,
+                                rocprim::maximum<int>(),
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            hipMalloc(&rocprim_buffer, rocprim_size);
+            DISCARD_HIP_ERROR(hipMalloc(&rocprim_buffer, rocprim_size));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            rocprim::reduce(rocprim_buffer,
-                            rocprim_size,
-                            csr_row_ptr,
-                            csr_row_ptr + nrow,
-                            0,
-                            nrow,
-                            rocprim::maximum<int>(),
-                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::reduce(rocprim_buffer,
+                                rocprim_size,
+                                csr_row_ptr,
+                                csr_row_ptr + nrow,
+                                0,
+                                nrow,
+                                rocprim::maximum<int>(),
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            hipFree(rocprim_buffer);
+            DISCARD_HIP_ERROR(hipFree(rocprim_buffer));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             // Get actual maximum row nnz on host
             copy_d2h(1, csr_row_ptr + nrow, &max_row_nnz);
 
             // Exclusive sum to obtain new row pointers
-            rocprim::exclusive_scan(NULL,
-                                    rocprim_size,
-                                    csr_row_ptr,
-                                    csr_row_ptr,
-                                    0,
-                                    nrow + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(NULL,
+                                        rocprim_size,
+                                        csr_row_ptr,
+                                        csr_row_ptr,
+                                        0,
+                                        nrow + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            hipMalloc(&rocprim_buffer, rocprim_size);
+            DISCARD_HIP_ERROR(hipMalloc(&rocprim_buffer, rocprim_size));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    csr_row_ptr,
-                                    csr_row_ptr,
-                                    0,
-                                    nrow + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(rocprim_buffer,
+                                        rocprim_size,
+                                        csr_row_ptr,
+                                        csr_row_ptr,
+                                        0,
+                                        nrow + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-            hipFree(rocprim_buffer);
+            DISCARD_HIP_ERROR(hipFree(rocprim_buffer));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             // Obtain nnz

--- a/src/base/hip/hip_matrix_dense.cpp
+++ b/src/base/hip/hip_matrix_dense.cpp
@@ -126,7 +126,8 @@ namespace rocalution
 
         this->Clear();
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         this->nrow_ = nrow;
         this->ncol_ = ncol;
@@ -143,7 +144,8 @@ namespace rocalution
         assert(this->nnz_ >= 0);
         assert(this->nnz_ == this->nrow_ * this->ncol_);
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         *val = this->mat_.val;
 

--- a/src/base/hip/hip_matrix_dia.cpp
+++ b/src/base/hip/hip_matrix_dia.cpp
@@ -136,7 +136,8 @@ namespace rocalution
 
         this->Clear();
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         this->mat_.num_diag = num_diag;
         this->nrow_         = nrow;
@@ -166,7 +167,8 @@ namespace rocalution
             assert(this->nnz_ == this->nrow_ * this->mat_.num_diag);
         }
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         *offset = this->mat_.offset;
         *val    = this->mat_.val;

--- a/src/base/hip/hip_matrix_ell.cpp
+++ b/src/base/hip/hip_matrix_ell.cpp
@@ -157,7 +157,8 @@ namespace rocalution
 
         this->Clear();
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         this->mat_.max_row = max_row;
         this->nrow_        = nrow;
@@ -179,7 +180,8 @@ namespace rocalution
         assert(this->mat_.max_row >= 0);
         assert(this->mat_.max_row * this->nrow_ == this->nnz_);
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // see free_host function for details
         *col = this->mat_.col;

--- a/src/base/hip/hip_matrix_mcsr.cpp
+++ b/src/base/hip/hip_matrix_mcsr.cpp
@@ -131,7 +131,8 @@ namespace rocalution
         this->ncol_ = ncol;
         this->nnz_  = nnz;
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         this->mat_.row_offset = *row_offset;
         this->mat_.col        = *col;
@@ -147,7 +148,8 @@ namespace rocalution
         assert(this->ncol_ >= 0);
         assert(this->nnz_ >= 0);
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         *row_offset = this->mat_.row_offset;
         *col        = this->mat_.col;

--- a/src/base/hip/hip_rsamg_csr.cpp
+++ b/src/base/hip/hip_rsamg_csr.cpp
@@ -610,27 +610,29 @@ namespace rocalution
 
         // Exclusive sum to obtain row offset pointers of P
         // P contains only nnz per row, so far
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                cast_pi->mat_.row_offset,
-                                cast_pi->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    cast_pi->mat_.row_offset,
+                                    cast_pi->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                cast_pi->mat_.row_offset,
-                                cast_pi->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    cast_pi->mat_.row_offset,
+                                    cast_pi->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Initialize nnz of P
@@ -652,14 +654,15 @@ namespace rocalution
         {
             // Exclusive sum to obtain row offset pointers of ghost
             // part of P
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    cast_pg->mat_.row_offset,
-                                    cast_pg->mat_.row_offset,
-                                    0,
-                                    this->nrow_ + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(rocprim_buffer,
+                                        rocprim_size,
+                                        cast_pg->mat_.row_offset,
+                                        cast_pg->mat_.row_offset,
+                                        0,
+                                        this->nrow_ + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             // Initialize nnz of P ghost
@@ -967,27 +970,29 @@ namespace rocalution
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Obtain maximum row nnz
-        rocprim::reduce(NULL,
-                        rocprim_size,
-                        cast_pi->mat_.row_offset,
-                        cast_pi->mat_.row_offset + this->nrow_,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<PtrType>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(NULL,
+                            rocprim_size,
+                            cast_pi->mat_.row_offset,
+                            cast_pi->mat_.row_offset + this->nrow_,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<PtrType>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-        rocprim::reduce(rocprim_buffer,
-                        rocprim_size,
-                        cast_pi->mat_.row_offset,
-                        cast_pi->mat_.row_offset + this->nrow_,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<PtrType>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(rocprim_buffer,
+                            rocprim_size,
+                            cast_pi->mat_.row_offset,
+                            cast_pi->mat_.row_offset + this->nrow_,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<PtrType>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         free_hip(&rocprim_buffer);
@@ -1185,26 +1190,28 @@ namespace rocalution
         int* d_max_hash = NULL;
         allocate_hip(2, &d_max_hash);
 
-        rocprim::reduce(NULL,
-                        rocprim_size,
-                        cast_pi->mat_.row_offset,
-                        d_max_hash,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(NULL,
+                            rocprim_size,
+                            cast_pi->mat_.row_offset,
+                            d_max_hash,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::reduce(rocprim_buffer,
-                        rocprim_size,
-                        cast_pi->mat_.row_offset,
-                        d_max_hash,
-                        0,
-                        this->nrow_,
-                        rocprim::maximum<int>(),
-                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::reduce(rocprim_buffer,
+                            rocprim_size,
+                            cast_pi->mat_.row_offset,
+                            d_max_hash,
+                            0,
+                            this->nrow_,
+                            rocprim::maximum<int>(),
+                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Maximum fill
@@ -1214,14 +1221,15 @@ namespace rocalution
         // Ghost part
         if(global == true)
         {
-            rocprim::reduce(rocprim_buffer,
-                            rocprim_size,
-                            cast_pg->mat_.row_offset,
-                            d_max_hash + 1,
-                            0,
-                            this->nrow_,
-                            rocprim::maximum<int>(),
-                            HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::reduce(rocprim_buffer,
+                                rocprim_size,
+                                cast_pg->mat_.row_offset,
+                                d_max_hash + 1,
+                                0,
+                                this->nrow_,
+                                rocprim::maximum<int>(),
+                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             int max_hash_fill_gst;
@@ -1235,27 +1243,29 @@ namespace rocalution
 
         // Exclusive sum to obtain row offset pointers of P
         // P contains only nnz per row, so far
-        rocprim::exclusive_scan(NULL,
-                                rocprim_size,
-                                cast_pi->mat_.row_offset,
-                                cast_pi->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(NULL,
+                                    rocprim_size,
+                                    cast_pi->mat_.row_offset,
+                                    cast_pi->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         rocprim_buffer = NULL;
         allocate_hip(rocprim_size, &rocprim_buffer);
 
-        rocprim::exclusive_scan(rocprim_buffer,
-                                rocprim_size,
-                                cast_pi->mat_.row_offset,
-                                cast_pi->mat_.row_offset,
-                                0,
-                                this->nrow_ + 1,
-                                rocprim::plus<PtrType>(),
-                                HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+        DISCARD_HIP_ERROR(
+            rocprim::exclusive_scan(rocprim_buffer,
+                                    rocprim_size,
+                                    cast_pi->mat_.row_offset,
+                                    cast_pi->mat_.row_offset,
+                                    0,
+                                    this->nrow_ + 1,
+                                    rocprim::plus<PtrType>(),
+                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
         CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         // Initialize nnz of P
@@ -1277,14 +1287,15 @@ namespace rocalution
         {
             // Exclusive sum to obtain row offset pointers of ghost
             // part of P
-            rocprim::exclusive_scan(rocprim_buffer,
-                                    rocprim_size,
-                                    cast_pg->mat_.row_offset,
-                                    cast_pg->mat_.row_offset,
-                                    0,
-                                    this->nrow_ + 1,
-                                    rocprim::plus<PtrType>(),
-                                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+            DISCARD_HIP_ERROR(
+                rocprim::exclusive_scan(rocprim_buffer,
+                                        rocprim_size,
+                                        cast_pg->mat_.row_offset,
+                                        cast_pg->mat_.row_offset,
+                                        0,
+                                        this->nrow_ + 1,
+                                        rocprim::plus<PtrType>(),
+                                        HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
             CHECK_HIP_ERROR(__FILE__, __LINE__);
 
             // Initialize nnz of P ghost

--- a/src/base/hip/hip_utils.hpp
+++ b/src/base/hip/hip_utils.hpp
@@ -53,6 +53,8 @@
 #define ROCSPARSE_HANDLE(handle) *static_cast<rocsparse_handle*>(handle)
 #define HIPSTREAM(handle) *static_cast<hipStream_t*>(handle)
 
+#define DISCARD_HIP_ERROR(stat_t) std::ignore = stat_t
+
 #define CHECK_HIP_ERROR(file, line)                              \
     {                                                            \
         hipError_t err_t;                                        \

--- a/src/base/hip/hip_vector.cpp
+++ b/src/base/hip/hip_vector.cpp
@@ -111,7 +111,8 @@ namespace rocalution
             assert(*ptr != NULL);
         }
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
 
         this->vec_  = *ptr;
         this->size_ = size;
@@ -122,7 +123,8 @@ namespace rocalution
     {
         assert(this->size_ >= 0);
 
-        hipDeviceSynchronize();
+        DISCARD_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(__FILE__, __LINE__);
         *ptr       = this->vec_;
         this->vec_ = NULL;
 
@@ -1690,30 +1692,32 @@ namespace rocalution
             if(cast_perm == NULL)
             {
                 // Sort without permutation
-                rocprim::radix_sort_keys(buffer,
-                                         size,
-                                         this->vec_,
-                                         cast_sort->vec_,
-                                         this->size_,
-                                         begin_bit,
-                                         end_bit,
-                                         HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                DISCARD_HIP_ERROR(rocprim::radix_sort_keys(
+                    buffer,
+                    size,
+                    this->vec_,
+                    cast_sort->vec_,
+                    this->size_,
+                    begin_bit,
+                    end_bit,
+                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
                 CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-                hipMalloc(&buffer, size);
+                DISCARD_HIP_ERROR(hipMalloc(&buffer, size));
                 CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-                rocprim::radix_sort_keys(buffer,
-                                         size,
-                                         this->vec_,
-                                         cast_sort->vec_,
-                                         this->size_,
-                                         begin_bit,
-                                         end_bit,
-                                         HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                DISCARD_HIP_ERROR(rocprim::radix_sort_keys(
+                    buffer,
+                    size,
+                    this->vec_,
+                    cast_sort->vec_,
+                    this->size_,
+                    begin_bit,
+                    end_bit,
+                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
                 CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-                hipFree(buffer);
+                DISCARD_HIP_ERROR(hipFree(buffer));
                 CHECK_HIP_ERROR(__FILE__, __LINE__);
             }
             else
@@ -1732,34 +1736,36 @@ namespace rocalution
                 CHECK_ROCSPARSE_ERROR(status, __FILE__, __LINE__);
 
                 // Radix sort pairs
-                rocprim::radix_sort_pairs(buffer,
-                                          size,
-                                          this->vec_,
-                                          cast_sort->vec_,
-                                          workspace,
-                                          cast_perm->vec_,
-                                          this->size_,
-                                          begin_bit,
-                                          end_bit,
-                                          HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                DISCARD_HIP_ERROR(rocprim::radix_sort_pairs(
+                    buffer,
+                    size,
+                    this->vec_,
+                    cast_sort->vec_,
+                    workspace,
+                    cast_perm->vec_,
+                    this->size_,
+                    begin_bit,
+                    end_bit,
+                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
                 CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-                hipMalloc(&buffer, size);
+                DISCARD_HIP_ERROR(hipMalloc(&buffer, size));
                 CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-                rocprim::radix_sort_pairs(buffer,
-                                          size,
-                                          this->vec_,
-                                          cast_sort->vec_,
-                                          workspace,
-                                          cast_perm->vec_,
-                                          this->size_,
-                                          begin_bit,
-                                          end_bit,
-                                          HIPSTREAM(_get_backend_descriptor()->HIP_stream_current));
+                DISCARD_HIP_ERROR(rocprim::radix_sort_pairs(
+                    buffer,
+                    size,
+                    this->vec_,
+                    cast_sort->vec_,
+                    workspace,
+                    cast_perm->vec_,
+                    this->size_,
+                    begin_bit,
+                    end_bit,
+                    HIPSTREAM(_get_backend_descriptor()->HIP_stream_current)));
                 CHECK_HIP_ERROR(__FILE__, __LINE__);
 
-                hipFree(buffer);
+                DISCARD_HIP_ERROR(hipFree(buffer));
                 CHECK_HIP_ERROR(__FILE__, __LINE__);
             }
         }


### PR DESCRIPTION
## Motivation

There are many nodiscard warnings in rocALUTION resulting from not checking the return status of rocPRIM and HIP runtime APIs. This PR fixes those warnings to reduce the spam during compilation.

## Technical Details

Define a DISCARD_HIP_ERROR macro that uses std::ignore to remove the compiler warning messages. The error status is checked by a follow-up call to CHECK_HIP_ERROR as is done throughout the code already.

## Test Plan

Ensure regular CI tests pass
