### PR TITLE
Add missing ROCALUTION_EXPORT to methods to fix Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,16 +121,14 @@ set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for
 
 include(CheckLanguage)
 include(CMakeDependentOption)
-message("AAAAAAAAAAAAAAAAAAAAAAA")
+
 check_language(HIP)
-message("BBBBBBBBBBBBBBBBBBBBBBB")
+
 cmake_dependent_option(USE_HIPCXX "Use CMake HIP language support" OFF CMAKE_HIP_COMPILER OFF)
-message("CCCCCCCCCCCCCCCCCCCCCCC USE_HIPCXX : ${USE_HIPCXX}")
+
 if(USE_HIPCXX)
-  message("Call enable_language(HIP)")
   enable_language(HIP)
 else()
-  message("Call find_package(HIP MODULE)")
   find_package(HIP MODULE) # hip_add_library is only provided by the find module
   if(NOT HIP_FOUND)
     message("-- HIP not found. Compiling WITHOUT HIP support.")
@@ -138,8 +136,6 @@ else()
 endif()
 
 cmake_dependent_option(SUPPORT_HIP "Compile WITH HIP support" ON "USE_HIPCXX OR HIP_FOUND" OFF)
-
-message("DDDDDDDDDDDDDDDDDDDDDD SUPPORT_HIP : ${SUPPORT_HIP}")
 
 # HIP related library dependencies
 if(SUPPORT_HIP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,10 +121,11 @@ set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for
 
 include(CheckLanguage)
 include(CMakeDependentOption)
-check_language(HIP)
 message("AAAAAAAAAAAAAAAAAAAAAAA")
+check_language(HIP)
+message("BBBBBBBBBBBBBBBBBBBBBBB")
 cmake_dependent_option(USE_HIPCXX "Use CMake HIP language support" OFF CMAKE_HIP_COMPILER OFF)
-message("AAAAAAAAAAAAAAAAAAAAAAA USE_HIPCXX : ${USE_HIPCXX}")
+message("CCCCCCCCCCCCCCCCCCCCCCC USE_HIPCXX : ${USE_HIPCXX}")
 if(USE_HIPCXX)
   message("Call enable_language(HIP)")
   enable_language(HIP)
@@ -138,7 +139,7 @@ endif()
 
 cmake_dependent_option(SUPPORT_HIP "Compile WITH HIP support" ON "USE_HIPCXX OR HIP_FOUND" OFF)
 
-message("BBBBBBBBBBBBBBBBBBBBBBBBBB SUPPORT_HIP : ${SUPPORT_HIP}")
+message("DDDDDDDDDDDDDDDDDDDDDD SUPPORT_HIP : ${SUPPORT_HIP}")
 
 # HIP related library dependencies
 if(SUPPORT_HIP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,18 +34,12 @@ endif()
 # Needed to pickup static library files
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH})
 
-message("ROCM_PATH : ${ROCM_PATH}")
-message("CMAKE_PREFIX_PATH : ${CMAKE_PREFIX_PATH}")
-
 # CMake modules
 list(APPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake
      ${ROCM_PATH}/lib/cmake/hip
      ${ROCM_PATH}/hip/cmake
      ${ROCM_PATH}/cmake)
-
-message("ROCM_PATH : ${ROCM_PATH}")
-message("CMAKE_MODULE_PATH : ${CMAKE_MODULE_PATH}")
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -123,9 +117,7 @@ include(CheckLanguage)
 include(CMakeDependentOption)
 
 check_language(HIP)
-
 cmake_dependent_option(USE_HIPCXX "Use CMake HIP language support" OFF CMAKE_HIP_COMPILER OFF)
-
 if(USE_HIPCXX)
   enable_language(HIP)
 else()
@@ -140,7 +132,6 @@ cmake_dependent_option(SUPPORT_HIP "Compile WITH HIP support" ON "USE_HIPCXX OR 
 # HIP related library dependencies
 if(SUPPORT_HIP)
   if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
-    message("Call find_package( hip REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm )")
     find_package( hip REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm )
   endif( )
   find_package(rocblas REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,18 @@ endif()
 # Needed to pickup static library files
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH})
 
+message("ROCM_PATH : ${ROCM_PATH}")
+message("CMAKE_PREFIX_PATH : ${CMAKE_PREFIX_PATH}")
+
 # CMake modules
 list(APPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake
      ${ROCM_PATH}/lib/cmake/hip
      ${ROCM_PATH}/hip/cmake
      ${ROCM_PATH}/cmake)
+
+message("ROCM_PATH : ${ROCM_PATH}")
+message("CMAKE_MODULE_PATH : ${CMAKE_MODULE_PATH}")
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -116,10 +122,14 @@ set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for
 include(CheckLanguage)
 include(CMakeDependentOption)
 check_language(HIP)
+message("AAAAAAAAAAAAAAAAAAAAAAA")
 cmake_dependent_option(USE_HIPCXX "Use CMake HIP language support" OFF CMAKE_HIP_COMPILER OFF)
+message("AAAAAAAAAAAAAAAAAAAAAAA USE_HIPCXX : ${USE_HIPCXX}")
 if(USE_HIPCXX)
+  message("Call enable_language(HIP)")
   enable_language(HIP)
 else()
+  message("Call find_package(HIP MODULE)")
   find_package(HIP MODULE) # hip_add_library is only provided by the find module
   if(NOT HIP_FOUND)
     message("-- HIP not found. Compiling WITHOUT HIP support.")
@@ -128,9 +138,12 @@ endif()
 
 cmake_dependent_option(SUPPORT_HIP "Compile WITH HIP support" ON "USE_HIPCXX OR HIP_FOUND" OFF)
 
+message("BBBBBBBBBBBBBBBBBBBBBBBBBB SUPPORT_HIP : ${SUPPORT_HIP}")
+
 # HIP related library dependencies
 if(SUPPORT_HIP)
   if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+    message("Call find_package( hip REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm )")
     find_package( hip REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm )
   endif( )
   find_package(rocblas REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,6 @@ set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for
 
 include(CheckLanguage)
 include(CMakeDependentOption)
-
 check_language(HIP)
 cmake_dependent_option(USE_HIPCXX "Use CMake HIP language support" OFF CMAKE_HIP_COMPILER OFF)
 if(USE_HIPCXX)

--- a/src/base/global_matrix.hpp
+++ b/src/base/global_matrix.hpp
@@ -57,31 +57,45 @@ namespace rocalution
     class GlobalMatrix : public Operator<ValueType>
     {
     public:
+        ROCALUTION_EXPORT
         GlobalMatrix();
         /** \brief Initialize a global matrix with a parallel manager */
+        ROCALUTION_EXPORT
         explicit GlobalMatrix(const ParallelManager& pm);
+        ROCALUTION_EXPORT
         virtual ~GlobalMatrix();
 
         /** \brief Return the number of rows in the global matrix. */
+        ROCALUTION_EXPORT
         virtual int64_t GetM(void) const;
+        ROCALUTION_EXPORT
         /** \brief Return the number of columns in the global matrix. */
+        ROCALUTION_EXPORT
         virtual int64_t GetN(void) const;
         /** \brief Return the number of non-zeros in the global matrix. */
+        ROCALUTION_EXPORT
         virtual int64_t GetNnz(void) const;
         /** \brief Return the number of rows in the interior matrix. */
+        ROCALUTION_EXPORT
         virtual int64_t GetLocalM(void) const;
         /** \brief Return the number of columns in the interior matrix. */
+        ROCALUTION_EXPORT
         virtual int64_t GetLocalN(void) const;
         /** \brief Return the number of non-zeros in the interior matrix. */
+        ROCALUTION_EXPORT
         virtual int64_t GetLocalNnz(void) const;
         /** \brief Return the number of rows in the ghost matrix. */
+        ROCALUTION_EXPORT
         virtual int64_t GetGhostM(void) const;
         /** \brief Return the number of columns in the ghost matrix. */
+        ROCALUTION_EXPORT
         virtual int64_t GetGhostN(void) const;
         /** \brief Return the number of non-zeros in the ghost matrix. */
+        ROCALUTION_EXPORT
         virtual int64_t GetGhostNnz(void) const;
 
         /** \brief Return the global matrix format id (see matrix_formats.hpp) */
+        ROCALUTION_EXPORT
         unsigned int GetFormat(void) const;
 
         /** \private */
@@ -90,10 +104,13 @@ namespace rocalution
         const LocalMatrix<ValueType>& GetGhost() const;
 
         /** \brief Move all data (i.e. move the part of the global matrix stored on this rank) to the accelerator */
+        ROCALUTION_EXPORT
         virtual void MoveToAccelerator(void);
         /** \brief Move all data (i.e. move the part of the global matrix stored on this rank) to the host */
+        ROCALUTION_EXPORT
         virtual void MoveToHost(void);
         /** \brief Shows simple info about the matrix. */
+        ROCALUTION_EXPORT
         virtual void Info(void) const;
 
         /** \brief Perform a sanity check of the matrix
@@ -105,20 +122,26 @@ namespace rocalution
         * \retval true if the matrix is ok (empty matrix is also ok).
         * \retval false if there is something wrong with the structure or values.
         */
+        ROCALUTION_EXPORT
         virtual bool Check(void) const;
 
         /** \brief Allocate CSR Matrix */
+        ROCALUTION_EXPORT
         void AllocateCSR(const std::string& name, int64_t local_nnz, int64_t ghost_nnz);
         /** \brief Allocate COO Matrix */
+        ROCALUTION_EXPORT
         void AllocateCOO(const std::string& name, int64_t local_nnz, int64_t ghost_nnz);
 
         /** \brief Clear (free) the matrix */
+        ROCALUTION_EXPORT
         virtual void Clear(void);
 
         /** \brief Set the parallel manager of a global matrix */
+        ROCALUTION_EXPORT
         void SetParallelManager(const ParallelManager& pm);
 
         /** \brief Initialize a CSR matrix on the host with externally allocated data */
+        ROCALUTION_EXPORT
         void SetDataPtrCSR(PtrType**   local_row_offset,
                            int**       local_col,
                            ValueType** local_val,
@@ -129,6 +152,7 @@ namespace rocalution
                            int64_t     local_nnz,
                            int64_t     ghost_nnz);
         /** \brief Initialize a COO matrix on the host with externally allocated data */
+        ROCALUTION_EXPORT
         void SetDataPtrCOO(int**       local_row,
                            int**       local_col,
                            ValueType** local_val,
@@ -140,20 +164,25 @@ namespace rocalution
                            int64_t     ghost_nnz);
 
         /** \brief Initialize a CSR matrix on the host with externally allocated local data */
+        ROCALUTION_EXPORT
         void SetLocalDataPtrCSR(
             PtrType** row_offset, int** col, ValueType** val, std::string name, int64_t nnz);
         /** \brief Initialize a COO matrix on the host with externally allocated local data */
+        ROCALUTION_EXPORT
         void SetLocalDataPtrCOO(
             int** row, int** col, ValueType** val, std::string name, int64_t nnz);
 
         /** \brief Initialize a CSR matrix on the host with externally allocated ghost data */
+        ROCALUTION_EXPORT
         void SetGhostDataPtrCSR(
             PtrType** row_offset, int** col, ValueType** val, std::string name, int64_t nnz);
         /** \brief Initialize a COO matrix on the host with externally allocated ghost data */
+        ROCALUTION_EXPORT
         void SetGhostDataPtrCOO(
             int** row, int** col, ValueType** val, std::string name, int64_t nnz);
 
         /** \brief Leave a CSR matrix to host pointers */
+        ROCALUTION_EXPORT
         void LeaveDataPtrCSR(PtrType**   local_row_offset,
                              int**       local_col,
                              ValueType** local_val,
@@ -161,6 +190,7 @@ namespace rocalution
                              int**       ghost_col,
                              ValueType** ghost_val);
         /** \brief Leave a COO matrix to host pointers */
+        ROCALUTION_EXPORT
         void LeaveDataPtrCOO(int**       local_row,
                              int**       local_col,
                              ValueType** local_val,
@@ -168,73 +198,97 @@ namespace rocalution
                              int**       ghost_col,
                              ValueType** ghost_val);
         /** \brief Leave a local CSR matrix to host pointers */
+        ROCALUTION_EXPORT
         void LeaveLocalDataPtrCSR(PtrType** row_offset, int** col, ValueType** val);
         /** \brief Leave a local COO matrix to host pointers */
+        ROCALUTION_EXPORT
         void LeaveLocalDataPtrCOO(int** row, int** col, ValueType** val);
         /** \brief Leave a CSR ghost matrix to host pointers */
+        ROCALUTION_EXPORT
         void LeaveGhostDataPtrCSR(PtrType** row_offset, int** col, ValueType** val);
         /** \brief Leave a COO ghost matrix to host pointers */
+        ROCALUTION_EXPORT
         void LeaveGhostDataPtrCOO(int** row, int** col, ValueType** val);
 
         /** \brief Clone the entire matrix (values,structure+backend descr) from another
         * GlobalMatrix
         */
+        ROCALUTION_EXPORT
         void CloneFrom(const GlobalMatrix<ValueType>& src);
         /** \brief Copy matrix (values and structure) from another GlobalMatrix */
+        ROCALUTION_EXPORT
         void CopyFrom(const GlobalMatrix<ValueType>& src);
 
         /** \brief Convert the matrix to CSR structure */
+        ROCALUTION_EXPORT
         void ConvertToCSR(void);
         /** \brief Convert the matrix to MCSR structure */
+        ROCALUTION_EXPORT
         void ConvertToMCSR(void);
         /** \brief Convert the matrix to BCSR structure */
+        ROCALUTION_EXPORT
         void ConvertToBCSR(int blockdim);
         /** \brief Convert the matrix to COO structure */
+        ROCALUTION_EXPORT
         void ConvertToCOO(void);
         /** \brief Convert the matrix to ELL structure */
+        ROCALUTION_EXPORT
         void ConvertToELL(void);
         /** \brief Convert the matrix to DIA structure */
+        ROCALUTION_EXPORT
         void ConvertToDIA(void);
         /** \brief Convert the matrix to HYB structure */
+        ROCALUTION_EXPORT
         void ConvertToHYB(void);
         /** \brief Convert the matrix to DENSE structure */
+        ROCALUTION_EXPORT
         void ConvertToDENSE(void);
         /** \brief Convert the matrix to specified matrix ID format */
+        ROCALUTION_EXPORT
         void ConvertTo(unsigned int matrix_format, int blockdim = 1);
 
         /** \brief Perform matrix-vector multiplication, out = this * in; */
+        ROCALUTION_EXPORT
         virtual void Apply(const GlobalVector<ValueType>& in, GlobalVector<ValueType>* out) const;
         /** \brief Perform matrix-vector multiplication, out = scalar * this * in; */
+        ROCALUTION_EXPORT
         virtual void ApplyAdd(const GlobalVector<ValueType>& in,
                               ValueType                      scalar,
                               GlobalVector<ValueType>*       out) const;
 
         /** \brief Transpose the matrix */
+        ROCALUTION_EXPORT
         virtual void Transpose(void);
 
         /** \brief Transpose the matrix */
+        ROCALUTION_EXPORT
         void Transpose(GlobalMatrix<ValueType>* T) const;
 
         /** \brief Triple matrix product C=RAP */
+        ROCALUTION_EXPORT
         void TripleMatrixProduct(const GlobalMatrix<ValueType>& R,
                                  const GlobalMatrix<ValueType>& A,
                                  const GlobalMatrix<ValueType>& P);
 
         /** \brief Read matrix from MTX (Matrix Market Format) file */
+        ROCALUTION_EXPORT
         void ReadFileMTX(const std::string& filename);
         /** \brief Write matrix to MTX (Matrix Market Format) file */
+        ROCALUTION_EXPORT
         void WriteFileMTX(const std::string& filename) const;
         /** \brief Read matrix from CSR (ROCALUTION binary format) file */
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
 #else
         [[deprecated("This function will be removed in a future release.")]]
 #endif
+        ROCALUTION_EXPORT
         void ReadFileCSR(const std::string& filename);
         /** \brief Write matrix to CSR (ROCALUTION binary format) file */
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
 #else
         [[deprecated("This function will be removed in a future release.")]]
 #endif
+        ROCALUTION_EXPORT
         void WriteFileCSR(const std::string& filename) const;
 
         /** \brief Read a matrix from a binary file using rocsparse I/O format */
@@ -251,20 +305,25 @@ namespace rocalution
         * - For CSR matrices, column values are sorted.
         * - For COO matrices, row indices are sorted.
         */
+        ROCALUTION_EXPORT
         void Sort(void);
 
         /** \brief Extract the diagonal values of the matrix into a GlobalVector */
+        ROCALUTION_EXPORT
         void ExtractDiagonal(GlobalVector<ValueType>* vec_diag) const;
 
         /** \brief Extract the inverse (reciprocal) diagonal values of the matrix into a
         * GlobalVector
         */
+        ROCALUTION_EXPORT
         void ExtractInverseDiagonal(GlobalVector<ValueType>* vec_inv_diag) const;
 
         /** \brief Scale all the values in the matrix */
+        ROCALUTION_EXPORT
         void Scale(ValueType alpha);
 
         /** \brief Initial Pairwise Aggregation scheme */
+        ROCALUTION_EXPORT
         void InitialPairwiseAggregation(ValueType         beta,
                                         int&              nc,
                                         LocalVector<int>* G,
@@ -273,6 +332,7 @@ namespace rocalution
                                         int&              rGsize,
                                         int               ordering) const;
         /** \brief Further Pairwise Aggregation scheme */
+        ROCALUTION_EXPORT
         void FurtherPairwiseAggregation(ValueType         beta,
                                         int&              nc,
                                         LocalVector<int>* G,
@@ -281,6 +341,7 @@ namespace rocalution
                                         int&              rGsize,
                                         int               ordering) const;
         /** \brief Build coarse operator for pairwise aggregation scheme */
+        ROCALUTION_EXPORT
         void CoarsenOperator(GlobalMatrix<ValueType>* Ac,
                              int                      nrow,
                              int                      ncol,
@@ -290,6 +351,7 @@ namespace rocalution
                              int                      rGsize) const;
 
         /** \brief Create a restriction and prolongation matrix operator based on an int vector map */
+        ROCALUTION_EXPORT
         void CreateFromMap(const LocalVector<int>&  map,
                            int64_t                  n,
                            int64_t                  m,
@@ -329,15 +391,19 @@ namespace rocalution
                                       GlobalMatrix<ValueType>*    prolong) const;
 
         /** \brief Ruge Stueben coarsening */
+        ROCALUTION_EXPORT
         void RSCoarsening(float eps, LocalVector<int>* CFmap, LocalVector<bool>* S) const;
         /** \brief Parallel maximal independent set coarsening for RS AMG*/
+        ROCALUTION_EXPORT
         void RSPMISCoarsening(float eps, LocalVector<int>* CFmap, LocalVector<bool>* S) const;
 
         /** \brief Ruge Stueben Direct Interpolation */
+        ROCALUTION_EXPORT
         void RSDirectInterpolation(const LocalVector<int>&  CFmap,
                                    const LocalVector<bool>& S,
                                    GlobalMatrix<ValueType>* prolong) const;
         /** \brief Ruge Stueben Ext+i Interpolation */
+        ROCALUTION_EXPORT
         void RSExtPIInterpolation(const LocalVector<int>&  CFmap,
                                   const LocalVector<bool>& S,
                                   bool                     FF1,

--- a/src/base/global_vector.hpp
+++ b/src/base/global_vector.hpp
@@ -52,17 +52,23 @@ namespace rocalution
     class GlobalVector : public Vector<ValueType>
     {
     public:
+        ROCALUTION_EXPORT
         GlobalVector();
         /** \brief Initialize a global vector with a parallel manager */
+        ROCALUTION_EXPORT
         explicit GlobalVector(const ParallelManager& pm);
+        ROCALUTION_EXPORT
         virtual ~GlobalVector();
 
         /** \brief Move all data (i.e. move the part of the global vector stored on this rank) to the accelerator */
+        ROCALUTION_EXPORT
         virtual void MoveToAccelerator(void);
         /** \brief Move all data (i.e. move the part of the global vector stored on this rank) to the host */
+        ROCALUTION_EXPORT
         virtual void MoveToHost(void);
 
         /** \brief Shows simple info about the matrix. */
+        ROCALUTION_EXPORT
         virtual void Info(void) const;
 
         /** \brief Perform a sanity check of the vector
@@ -73,11 +79,14 @@ namespace rocalution
         * \retval true if the vector is ok (empty vector is also ok).
         * \retval false if there is something wrong with the values.
         */
+        ROCALUTION_EXPORT
         virtual bool Check(void) const;
 
         /** \brief Return the size of the global vector. */
+        ROCALUTION_EXPORT
         virtual int64_t GetSize(void) const;
         /** \brief Return the size of the interior part of the global vector. */
+        ROCALUTION_EXPORT
         virtual int64_t GetLocalSize(void) const;
 
         /** \private */
@@ -86,105 +95,143 @@ namespace rocalution
         LocalVector<ValueType>& GetInterior();
 
         /** \brief Allocate a global vector with name and size */
+        ROCALUTION_EXPORT
         virtual void Allocate(std::string name, int64_t size);
 
         /** \brief Clear (free) the vector */
+        ROCALUTION_EXPORT
         virtual void Clear(void);
 
         /** \brief Set the parallel manager of a global vector */
+        ROCALUTION_EXPORT
         void SetParallelManager(const ParallelManager& pm);
 
         /** \brief Set all vector interior values to zero */
+        ROCALUTION_EXPORT
         virtual void Zeros(void);
         /** \brief Set all vector interior values to ones */
+        ROCALUTION_EXPORT
         virtual void Ones(void);
         /** \brief Set the values of the interior vector to given argument */
+        ROCALUTION_EXPORT
         virtual void SetValues(ValueType val);
         /** \brief Set the values of the interior vector to random uniformly distributed values (between -1 and 1) */
+        ROCALUTION_EXPORT
         virtual void SetRandomUniform(unsigned long long seed,
                                       ValueType          a = static_cast<ValueType>(-1),
                                       ValueType          b = static_cast<ValueType>(1));
         /** \brief Set the values of the interior vector to random normally distributed values (between 0 and 1) */
+        ROCALUTION_EXPORT
         virtual void SetRandomNormal(unsigned long long seed,
                                      ValueType          mean = static_cast<ValueType>(0),
                                      ValueType          var  = static_cast<ValueType>(1));
         /** \brief Clone the entire vector (values,structure+backend descr) from another
         * GlobalVector
         */
+        ROCALUTION_EXPORT
         void CloneFrom(const GlobalVector<ValueType>& src);
 
         /** \brief Access operator (only for host data) */
+        ROCALUTION_EXPORT
         ValueType& operator[](int64_t i);
         /** \brief Access operator (only for host data) */
+        ROCALUTION_EXPORT
         const ValueType& operator[](int64_t i) const;
 
         /** \brief Initialize the local part of a global vector with externally allocated
       * data
       */
+        ROCALUTION_EXPORT
         void SetDataPtr(ValueType** ptr, std::string name, int64_t size);
         /** \brief Get a pointer to the data from the local part of a global vector and free
       * the global vector object
       */
+        ROCALUTION_EXPORT
         void LeaveDataPtr(ValueType** ptr);
 
         /** \brief Copy vector (values and structure) from another GlobalVector */
+        ROCALUTION_EXPORT
         virtual void CopyFrom(const GlobalVector<ValueType>& src);
         /** \brief Read GlobalVector from ASCII file. This method reads the current ranks interior vector from the file */
+        ROCALUTION_EXPORT
         virtual void ReadFileASCII(const std::string& filename);
         /** \brief Write GlobalVector to ASCII file. This method writes the current ranks interior vector to the file */
+        ROCALUTION_EXPORT
         virtual void WriteFileASCII(const std::string& filename) const;
         /** \brief Read GlobalVector from binary file. This method reads the current ranks interior vector from the file */
+        ROCALUTION_EXPORT
         virtual void ReadFileBinary(const std::string& filename);
         /** \brief Write GlobalVector to binary file. This method writes the current ranks interior vector to the file */
+        ROCALUTION_EXPORT
         virtual void WriteFileBinary(const std::string& filename) const;
 
         /** \brief Perform scalar-vector multiplication and add it to another vector, this = this + alpha * x; */
+        ROCALUTION_EXPORT
         virtual void AddScale(const GlobalVector<ValueType>& x, ValueType alpha);
         /** \brief Perform scalar-vector multiplication and add another vector, this = alpha * this + x; */
+        ROCALUTION_EXPORT
         virtual void ScaleAdd(ValueType alpha, const GlobalVector<ValueType>& x);
         /** \brief Perform vector update of type this = alpha*this + x*beta + y*gamma */
+        ROCALUTION_EXPORT
         virtual void ScaleAdd2(ValueType                      alpha,
                                const GlobalVector<ValueType>& x,
                                ValueType                      beta,
                                const GlobalVector<ValueType>& y,
                                ValueType                      gamma);
         /** \brief Perform scalar-vector multiplication and add another scaled vector (i.e. axpby), this = alpha * this + beta * x; */
+        ROCALUTION_EXPORT
         virtual void
             ScaleAddScale(ValueType alpha, const GlobalVector<ValueType>& x, ValueType beta);
         /** \brief Scale vector, this = alpha * this; */
+        ROCALUTION_EXPORT
         virtual void Scale(ValueType alpha);
         /** \brief Perform dot product */
+        ROCALUTION_EXPORT
         virtual ValueType Dot(const GlobalVector<ValueType>& x) const;
         /** \brief Perform non conjugate (when T is complex) dot product */
+        ROCALUTION_EXPORT
         virtual ValueType DotNonConj(const GlobalVector<ValueType>& x) const;
         /** \brief Compute L2 (Euclidean) norm of vector */
+        ROCALUTION_EXPORT
         virtual ValueType Norm(void) const;
         /** \brief Reduce (sum) the vector components */
+        ROCALUTION_EXPORT
         virtual ValueType Reduce(void) const;
         /** \brief Compute inclsuive sum of vector */
+        ROCALUTION_EXPORT
         virtual ValueType InclusiveSum(void);
         /** \brief Compute inclsuive sum of vector */
+        ROCALUTION_EXPORT
         virtual ValueType InclusiveSum(const GlobalVector<ValueType>& vec);
         /** \brief Compute exclsuive sum of vector */
+        ROCALUTION_EXPORT
         virtual ValueType ExclusiveSum(void);
         /** \brief Compute exclsuive sum of vector */
+        ROCALUTION_EXPORT
         virtual ValueType ExclusiveSum(const GlobalVector<ValueType>& vec);
         /** \brief Compute absolute value sum of vector components */
+        ROCALUTION_EXPORT
         virtual ValueType Asum(void) const;
         /** \brief Compute maximum absolute value component of vector */
+        ROCALUTION_EXPORT
         virtual int64_t Amax(ValueType& value) const;
         /** \brief Perform pointwise multiplication of vector */
+        ROCALUTION_EXPORT
         virtual void PointWiseMult(const GlobalVector<ValueType>& x);
         /** \brief Perform pointwise multiplication of vector */
+        ROCALUTION_EXPORT
         virtual void PointWiseMult(const GlobalVector<ValueType>& x,
                                    const GlobalVector<ValueType>& y);
         /** \brief Take the power of each vector component */
+        ROCALUTION_EXPORT
         virtual void Power(double power);
 
         /** \brief Restriction operator based on restriction mapping vector */
+        ROCALUTION_EXPORT
         void Restriction(const GlobalVector<ValueType>& vec_fine, const LocalVector<int>& map);
 
         /** \brief Prolongation operator based on restriction mapping vector */
+        ROCALUTION_EXPORT
         void Prolongation(const GlobalVector<ValueType>& vec_coarse, const LocalVector<int>& map);
 
     protected:

--- a/src/base/local_matrix.cpp
+++ b/src/base/local_matrix.cpp
@@ -1863,7 +1863,7 @@ namespace rocalution
             format += sstr.str();
         }
 
-        LOG_INFO("LocalMatrix" 
+        LOG_INFO("LocalMatrix"
                  << " name=" << this->object_name_ << ";"
                  << " rows=" << this->GetM() << ";"
                  << " cols=" << this->GetN() << ";"

--- a/src/base/local_matrix.cpp
+++ b/src/base/local_matrix.cpp
@@ -1863,16 +1863,17 @@ namespace rocalution
             format += sstr.str();
         }
 
-        LOG_INFO("LocalMatrix" << " name=" << this->object_name_ << ";"
-                               << " rows=" << this->GetM() << ";"
-                               << " cols=" << this->GetN() << ";"
-                               << " nnz=" << this->GetNnz() << ";"
-                               << " prec=" << 8 * sizeof(ValueType) << "bit;"
-                               << " format=" << format << ";"
-                               << " host backend={" << _rocalution_host_name[0] << "};"
-                               << " accelerator backend={"
-                               << _rocalution_backend_name[this->local_backend_.backend] << "};"
-                               << " current=" << current_backend_name);
+        LOG_INFO("LocalMatrix" 
+                 << " name=" << this->object_name_ << ";"
+                 << " rows=" << this->GetM() << ";"
+                 << " cols=" << this->GetN() << ";"
+                 << " nnz=" << this->GetNnz() << ";"
+                 << " prec=" << 8 * sizeof(ValueType) << "bit;"
+                 << " format=" << format << ";"
+                 << " host backend={" << _rocalution_host_name[0] << "};"
+                 << " accelerator backend={"
+                 << _rocalution_backend_name[this->local_backend_.backend] << "};"
+                 << " current=" << current_backend_name);
 
         // this->matrix_->Info();
     }

--- a/src/base/local_matrix.cpp
+++ b/src/base/local_matrix.cpp
@@ -1863,17 +1863,16 @@ namespace rocalution
             format += sstr.str();
         }
 
-        LOG_INFO("LocalMatrix"
-                 << " name=" << this->object_name_ << ";"
-                 << " rows=" << this->GetM() << ";"
-                 << " cols=" << this->GetN() << ";"
-                 << " nnz=" << this->GetNnz() << ";"
-                 << " prec=" << 8 * sizeof(ValueType) << "bit;"
-                 << " format=" << format << ";"
-                 << " host backend={" << _rocalution_host_name[0] << "};"
-                 << " accelerator backend={"
-                 << _rocalution_backend_name[this->local_backend_.backend] << "};"
-                 << " current=" << current_backend_name);
+        LOG_INFO("LocalMatrix" << " name=" << this->object_name_ << ";"
+                               << " rows=" << this->GetM() << ";"
+                               << " cols=" << this->GetN() << ";"
+                               << " nnz=" << this->GetNnz() << ";"
+                               << " prec=" << 8 * sizeof(ValueType) << "bit;"
+                               << " format=" << format << ";"
+                               << " host backend={" << _rocalution_host_name[0] << "};"
+                               << " accelerator backend={"
+                               << _rocalution_backend_name[this->local_backend_.backend] << "};"
+                               << " current=" << current_backend_name);
 
         // this->matrix_->Info();
     }
@@ -3308,7 +3307,7 @@ namespace rocalution
 
                 err = mat_csr.matrix_->ItLUSolve(
                     max_iter, tolerance, use_tol, *in.vector_, out->vector_);
-                if((err == false))
+                if(err == false)
                 {
                     LOG_INFO("Computation of LocalMatrix::ItLUSolve() failed");
                     mat_csr.Info();
@@ -3428,7 +3427,7 @@ namespace rocalution
 
                 err = mat_csr.matrix_->ItLLSolve(
                     max_iter, tolerance, use_tol, *in.vector_, out->vector_);
-                if((err == false))
+                if(err == false)
                 {
                     LOG_INFO("Computation of LocalMatrix::ItLLSolve() failed");
                     mat_csr.Info();
@@ -3535,7 +3534,7 @@ namespace rocalution
 
                 err = mat_csr.matrix_->ItLLSolve(
                     max_iter, tolerance, use_tol, *in.vector_, *inv_diag.vector_, out->vector_);
-                if((err == false))
+                if(err == false)
                 {
                     LOG_INFO("Computation of LocalMatrix::ItLLSolve() failed");
                     mat_csr.Info();
@@ -3655,7 +3654,7 @@ namespace rocalution
 
                 err = mat_csr.matrix_->ItLSolve(
                     max_iter, tolerance, use_tol, *in.vector_, out->vector_);
-                if((err == false))
+                if(err == false)
                 {
                     LOG_INFO("Computation of LocalMatrix::ItLSolve() failed");
                     mat_csr.Info();
@@ -3772,7 +3771,7 @@ namespace rocalution
 
                 err = mat_csr.matrix_->ItUSolve(
                     max_iter, tolerance, use_tol, *in.vector_, out->vector_);
-                if((err == false))
+                if(err == false)
                 {
                     LOG_INFO("Computation of LocalMatrix::ItUSolve() failed");
                     mat_csr.Info();

--- a/src/base/vector.hpp
+++ b/src/base/vector.hpp
@@ -363,15 +363,19 @@ namespace rocalution
         /** \brief Compute Inclusive sum */
         virtual ValueType InclusiveSum(void) = 0;
         /** \brief Compute Inclusive sum */
+        ROCALUTION_EXPORT
         virtual ValueType InclusiveSum(const LocalVector<ValueType>& vec);
         /** \brief Compute Inclusive sum */
+        ROCALUTION_EXPORT
         virtual ValueType InclusiveSum(const GlobalVector<ValueType>& vec);
 
         /** \brief Compute exclusive sum */
         virtual ValueType ExclusiveSum(void) = 0;
         /** \brief Compute exclusive sum */
+        ROCALUTION_EXPORT
         virtual ValueType ExclusiveSum(const LocalVector<ValueType>& vec);
         /** \brief Compute exclusive sum */
+        ROCALUTION_EXPORT
         virtual ValueType ExclusiveSum(const GlobalVector<ValueType>& vec);
 
         /** \brief Compute the sum of absolute values of the vector, return = sum(|this|) */

--- a/src/solvers/iter_ctrl.hpp
+++ b/src/solvers/iter_ctrl.hpp
@@ -37,76 +37,100 @@ namespace rocalution
     class IterationControl
     {
     public:
+        ROCALUTION_EXPORT
         IterationControl();
+        ROCALUTION_EXPORT
         ~IterationControl();
 
         // Initialize with absolute/relative/divergence
         // tolerance and maximum number of iterations
+        ROCALUTION_EXPORT
         void Init(double abs, double rel, double div, int max);
 
         // Initialize with absolute/relative/divergence
         // tolerance and minimum/maximum number of iterations
+        ROCALUTION_EXPORT
         void Init(double abs, double rel, double div, int min, int max);
 
         // Initialize with absolute/relative/divergence tolerance
+        ROCALUTION_EXPORT
         void InitTolerance(double abs, double rel, double div);
 
         // Set the minimum number of iterations
+        ROCALUTION_EXPORT
         void InitMinimumIterations(int min);
 
         // Set the maximal number of iterations
+        ROCALUTION_EXPORT
         void InitMaximumIterations(int max);
 
         // Get the minimum number of iterations
+        ROCALUTION_EXPORT
         int GetMinimumIterations(void) const;
 
         // Get the maximal number of iterations
+        ROCALUTION_EXPORT
         int GetMaximumIterations(void) const;
 
         // Initialize the initial residual
+        ROCALUTION_EXPORT
         bool InitResidual(double res);
 
         // Clear (reset)
+        ROCALUTION_EXPORT
         void Clear(void);
 
         // Check the residual (this count also the number of iterations)
+        ROCALUTION_EXPORT
         bool CheckResidual(double res);
 
         // Check the residual and index value for the inf norm
         // (this count also the number of iterations)
+        ROCALUTION_EXPORT
         bool CheckResidual(double res, int64_t index);
 
         // Check the residual (without counting the number of iterations)
+        ROCALUTION_EXPORT
         bool CheckResidualNoCount(double res);
 
         // Check for maximum iterations (without counting the number of iterations)
+        ROCALUTION_EXPORT
         bool CheckMaximumIterNoCount(void);
 
         // Record the history of the residual
+        ROCALUTION_EXPORT
         void RecordHistory(void);
 
         // Write the history of the residual to an ASCII file
+        ROCALUTION_EXPORT
         void WriteHistoryToFile(const std::string& filename) const;
 
         // Provide verbose output of the solver (iter, residual)
+        ROCALUTION_EXPORT
         void Verbose(int verb = 1);
 
         // Print the initialized information of the iteration control
+        ROCALUTION_EXPORT
         void PrintInit(void) const;
 
         // Print the current status (is the any criteria reached or not)
+        ROCALUTION_EXPORT
         void PrintStatus(void);
 
         // Return the iteration count
+        ROCALUTION_EXPORT
         int GetIterationCount(void) const;
 
         // Return the current residual
+        ROCALUTION_EXPORT
         double GetCurrentResidual(void) const;
 
         // Return the current status
+        ROCALUTION_EXPORT
         int GetSolverStatus(void) const;
 
         // Return absolute maximum index of residual vector when using Linf norm
+        ROCALUTION_EXPORT
         int64_t GetAmaxResidualIndex(void) const;
 
     private:

--- a/src/solvers/iter_ctrl.hpp
+++ b/src/solvers/iter_ctrl.hpp
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include "rocalution/export.hpp"
+
 namespace rocalution
 {
 

--- a/src/solvers/multigrid/base_amg.hpp
+++ b/src/solvers/multigrid/base_amg.hpp
@@ -69,7 +69,9 @@ namespace rocalution
     class BaseAMG : public BaseMultiGrid<OperatorType, VectorType, ValueType>
     {
     public:
+        ROCALUTION_EXPORT
         BaseAMG();
+        ROCALUTION_EXPORT
         virtual ~BaseAMG();
 
         ROCALUTION_EXPORT
@@ -78,6 +80,7 @@ namespace rocalution
         virtual void Clear(void);
 
         /** \brief Clear all local data */
+        ROCALUTION_EXPORT
         virtual void ClearLocal(void);
 
         /** \brief Create AMG hierarchy */
@@ -85,6 +88,7 @@ namespace rocalution
         virtual void BuildHierarchy(void);
 
         /** \brief Create AMG smoothers */
+        ROCALUTION_EXPORT
         virtual void BuildSmoothers(void);
 
         /** \brief Set coarsest level for hierarchy creation */
@@ -110,10 +114,13 @@ namespace rocalution
         int GetNumLevels(void);
 
         /** \private */
+        ROCALUTION_EXPORT
         virtual void SetRestrictOperator(OperatorType** op);
         /** \private */
+        ROCALUTION_EXPORT
         virtual void SetProlongOperator(OperatorType** op);
         /** \private */
+        ROCALUTION_EXPORT
         virtual void SetOperatorHierarchy(OperatorType** op);
 
     protected:

--- a/src/solvers/multigrid/base_multigrid.hpp
+++ b/src/solvers/multigrid/base_multigrid.hpp
@@ -52,7 +52,9 @@ namespace rocalution
     class BaseMultiGrid : public IterativeLinearSolver<OperatorType, VectorType, ValueType>
     {
     public:
+        ROCALUTION_EXPORT
         BaseMultiGrid();
+        ROCALUTION_EXPORT
         virtual ~BaseMultiGrid();
 
         ROCALUTION_EXPORT
@@ -79,12 +81,15 @@ namespace rocalution
         void SetSmootherPostIter(int iter);
 
         /** \brief Set the restriction operator for each level */
+        ROCALUTION_EXPORT
         virtual void SetRestrictOperator(OperatorType** op) = 0;
 
         /** \brief Set the prolongation operator for each level */
+        ROCALUTION_EXPORT
         virtual void SetProlongOperator(OperatorType** op) = 0;
 
         /** \brief Set the operator for each level */
+        ROCALUTION_EXPORT
         virtual void SetOperatorHierarchy(OperatorType** op) = 0;
 
         /** \brief Enable/disable scaling of intergrid transfers */
@@ -112,12 +117,16 @@ namespace rocalution
         virtual void Solve(const VectorType& rhs, VectorType* x);
 
         /** \brief Build multigrid solver */
+        ROCALUTION_EXPORT
         virtual void Build(void);
         /** \brief Initialize multigrid solver (called from Build()) */
+        ROCALUTION_EXPORT
         virtual void Initialize(void);
         /** \brief Clear multigrid solver */
+        ROCALUTION_EXPORT
         virtual void Clear(void);
         /** \brief Finalize multigrid solver (called from Clear()) */
+        ROCALUTION_EXPORT
         virtual void Finalize(void);
 
     protected:

--- a/src/solvers/preconditioners/preconditioner_multicolored.hpp
+++ b/src/solvers/preconditioners/preconditioner_multicolored.hpp
@@ -45,19 +45,26 @@ namespace rocalution
     class MultiColored : public Preconditioner<OperatorType, VectorType, ValueType>
     {
     public:
+        ROCALUTION_EXPORT
         MultiColored();
+        ROCALUTION_EXPORT
         virtual ~MultiColored();
 
+        ROCALUTION_EXPORT
         virtual void Clear(void);
 
+        ROCALUTION_EXPORT
         virtual void Build(void);
 
         /** \brief Set a specific matrix type of the decomposed block matrices */
+        ROCALUTION_EXPORT
         void SetPrecondMatrixFormat(unsigned int mat_format, int blockdim = 1);
 
         /** \brief Set if the preconditioner should be decomposed or not */
+        ROCALUTION_EXPORT
         void SetDecomposition(bool decomp);
 
+        ROCALUTION_EXPORT
         virtual void Solve(const VectorType& rhs, VectorType* x);
 
     protected:

--- a/src/solvers/preconditioners/preconditioner_multielimination.hpp
+++ b/src/solvers/preconditioners/preconditioner_multielimination.hpp
@@ -69,6 +69,7 @@ namespace rocalution
 
         // LCOV_EXCL_START
         /** \brief Returns the size of the first (diagonal) block of the preconditioner */
+        ROCALUTION_EXPORT
         inline int GetSizeDiagBlock(void) const
         {
             // LCOV_EXCL_STOP
@@ -79,6 +80,7 @@ namespace rocalution
 
         // LCOV_EXCL_START
         /** \brief Return the depth of the current level */
+        ROCALUTION_EXPORT
         inline int GetLevel(void) const
         {
             // LCOV_EXCL_STOP

--- a/src/solvers/solver.hpp
+++ b/src/solvers/solver.hpp
@@ -247,6 +247,7 @@ namespace rocalution
 
         // LCOV_EXCL_START
         /** \brief Mark this solver as being a preconditioner */
+        ROCALUTION_EXPORT
         inline void FlagPrecond(void)
         {
             // LCOV_EXCL_STOP
@@ -257,6 +258,7 @@ namespace rocalution
 
         // LCOV_EXCL_START
         /** \brief Mark this solver as being a smoother */
+        ROCALUTION_EXPORT
         inline void FlagSmoother(void)
         {
             // LCOV_EXCL_STOP


### PR DESCRIPTION
## Motivation

Many methods were missing ROCALUTION_EXPORT which would cause missing symbols in the Windows rocalution.dll. This then would cause link errors if a user ever attempted to use those methods in a program. This PR also fixes some warnings that occurred on Windows.
