### PR TITLE
Docs: resolving Doxygen warnings and minor fixes 

### DIFF
--- a/docs/reference/rocALUTION-accelerators.rst
+++ b/docs/reference/rocALUTION-accelerators.rst
@@ -5,7 +5,7 @@
 .. _backends:
 
 ******************************
-rocALUTIN accelerator support
+rocALUTION accelerator support
 ******************************
 
 The rocALUTION structure is embedded with the support for accelerator devices. It is recommended to use accelerators to decrease the computational time.

--- a/docs/reference/rocALUTION-multi-node-comp.rst
+++ b/docs/reference/rocALUTION-multi-node-comp.rst
@@ -69,13 +69,9 @@ The parallel manager class hosts the following functions:
 
 .. doxygenfunction:: rocalution::ParallelManager::SetMPICommunicator
 .. doxygenfunction:: rocalution::ParallelManager::Clear
-.. doxygenfunction:: rocalution::ParallelManager::GetGlobalSize
-.. doxygenfunction:: rocalution::ParallelManager::GetLocalSize
 .. doxygenfunction:: rocalution::ParallelManager::GetNumReceivers
 .. doxygenfunction:: rocalution::ParallelManager::GetNumSenders
 .. doxygenfunction:: rocalution::ParallelManager::GetNumProcs
-.. doxygenfunction:: rocalution::ParallelManager::SetGlobalSize
-.. doxygenfunction:: rocalution::ParallelManager::SetLocalSize
 .. doxygenfunction:: rocalution::ParallelManager::SetBoundaryIndex
 .. doxygenfunction:: rocalution::ParallelManager::SetReceivers
 .. doxygenfunction:: rocalution::ParallelManager::SetSenders


### PR DESCRIPTION
## Motivation

removing deprecated functions from the documentations